### PR TITLE
Change the details shown in the evaluation component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@types/node": "^24.10.1",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
@@ -1448,6 +1449,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.2",
@@ -3530,6 +3541,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@types/node": "^24.10.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",

--- a/client/src/components/Evaluation.tsx
+++ b/client/src/components/Evaluation.tsx
@@ -7,7 +7,7 @@ interface EvaluationMetricsProps {
 // Blue color palette for progress bars
 const PROGRESS_BAR_COLOR = "#3b82f6"; // Primary blue
 
-const EvaluationMetrics = ({ evaluationResponse }: EvaluationMetricsProps) => {
+const Evaluation = ({ evaluationResponse }: EvaluationMetricsProps) => {
   const metrics = evaluationResponse.results[0];
   
   if (!metrics) {
@@ -131,4 +131,4 @@ const EvaluationMetrics = ({ evaluationResponse }: EvaluationMetricsProps) => {
   );
 };
 
-export default EvaluationMetrics;
+export default Evaluation;

--- a/client/src/components/Evaluation.tsx
+++ b/client/src/components/Evaluation.tsx
@@ -1,15 +1,21 @@
-import type { EvaluationResponse } from "../types";
+import type { EvaluationResponse, EvaluationMetrics } from "../types";
 
-interface EvaluationMetricsProps {
+interface EvaluationProps {
   evaluationResponse: EvaluationResponse;
 }
 
-// Blue color palette for progress bars
-const PROGRESS_BAR_COLOR = "#3b82f6"; // Primary blue
+const PROGRESS_BAR_COLOR = "#3b82f6";
 
-const Evaluation = ({ evaluationResponse }: EvaluationMetricsProps) => {
+const METRIC_CONFIG: { key: keyof EvaluationMetrics; name: string; description: string }[] = [
+  { key: "precision_mean", name: "Precision", description: "Accuracy of retrieved chunks" },
+  { key: "precision_omega_mean", name: "Precision Omega", description: "Weighted precision metric" },
+  { key: "recall_mean", name: "Recall", description: "Coverage of relevant information" },
+  { key: "iou_mean", name: "IoU", description: "Intersection over Union score" },
+];
+
+const Evaluation = ({ evaluationResponse }: EvaluationProps) => {
   const metrics = evaluationResponse.results[0];
-  
+
   if (!metrics) {
     return (
       <div className="evaluation-container">
@@ -17,17 +23,6 @@ const Evaluation = ({ evaluationResponse }: EvaluationMetricsProps) => {
       </div>
     );
   }
-
-  const precisionValue = metrics.precision_mean.toFixed(3);
-  const recallValue = metrics.recall_mean.toFixed(3);
-  const iouValue = metrics.iou_mean.toFixed(3);
-  const precisionOmegaValue = metrics.precision_omega_mean.toFixed(3);
-
-  // For progress bar width, convert to percentage
-  const precisionPercent = metrics.precision_mean * 100;
-  const recallPercent = metrics.recall_mean * 100;
-  const iouPercent = metrics.iou_mean * 100;
-  const precisionOmegaPercent = metrics.precision_omega_mean * 100;
 
   return (
     <div className="evaluation-container">
@@ -41,91 +36,36 @@ const Evaluation = ({ evaluationResponse }: EvaluationMetricsProps) => {
       </div>
 
       <div className="queries-info">
-        <p>
-          <strong>Queries S3 Path:</strong>{" "}
-          <code>{evaluationResponse.queries_s3_key}</code>
-        </p>
         <p className="queries-status">
           {evaluationResponse.queries_generated
-            ? `✓ New queries were generated${evaluationResponse.num_queries ? ` (${evaluationResponse.num_queries} queries)` : ""}`
+            ? `✓ New queries were generated (${evaluationResponse.num_queries ?? 0} queries)`
             : "✓ Existing queries were used"}
+        </p>
+        <p>
+          <strong>Queries Path:</strong>{" "}
+          <code>{evaluationResponse.queries_s3_key}</code>
         </p>
       </div>
 
       <div className="metrics-list">
-        <div className="metric-item">
-          <div className="metric-header">
-            <span className="metric-name">Precision</span>
-            <span className="metric-value">{precisionValue}</span>
+        {METRIC_CONFIG.map(({ key, name, description }) => (
+          <div key={key} className="metric-item">
+            <div className="metric-header">
+              <span className="metric-name">{name}</span>
+              <span className="metric-value">{metrics[key].toFixed(3)}</span>
+            </div>
+            <p className="metric-description">{description}</p>
+            <div className="progress-bar">
+              <div
+                className="progress-fill"
+                style={{
+                  width: `${metrics[key] * 100}%`,
+                  backgroundColor: PROGRESS_BAR_COLOR,
+                }}
+              />
+            </div>
           </div>
-          <p className="metric-description">Accuracy of retrieved chunks</p>
-          <div className="progress-bar">
-            <div
-              className="progress-fill"
-              style={{
-                width: `${precisionPercent}%`,
-                backgroundColor: PROGRESS_BAR_COLOR,
-              }}
-            />
-          </div>
-        </div>
-
-        <div className="metric-item">
-          <div className="metric-header">
-            <span className="metric-name">Precision Omega</span>
-            <span className="metric-value">{precisionOmegaValue}</span>
-          </div>
-          <p className="metric-description">Weighted precision metric</p>
-          <div className="progress-bar">
-            <div
-              className="progress-fill"
-              style={{
-                width: `${precisionOmegaPercent}%`,
-                backgroundColor: PROGRESS_BAR_COLOR,
-              }}
-            />
-          </div>
-        </div>
-
-        <div className="metric-item">
-          <div className="metric-header">
-            <span className="metric-name">Recall</span>
-            <span className="metric-value">{recallValue}</span>
-          </div>
-          <p className="metric-description">Coverage of relevant information</p>
-          <div className="progress-bar">
-            <div
-              className="progress-fill"
-              style={{
-                width: `${recallPercent}%`,
-                backgroundColor: PROGRESS_BAR_COLOR,
-              }}
-            />
-          </div>
-        </div>
-
-        <div className="metric-item">
-          <div className="metric-header">
-            <span className="metric-name">IoU</span>
-            <span className="metric-value">{iouValue}</span>
-          </div>
-          <p className="metric-description">Intersection over Union score</p>
-          <div className="progress-bar">
-            <div
-              className="progress-fill"
-              style={{
-                width: `${iouPercent}%`,
-                backgroundColor: PROGRESS_BAR_COLOR,
-              }}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="evaluation-note">
-        <strong>Note:</strong> These metrics are calculated based on a test
-        query set to evaluate how well your chunking strategy performs for
-        retrieval tasks.
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/EvaluationMetrics.tsx
+++ b/client/src/components/EvaluationMetrics.tsx
@@ -1,42 +1,33 @@
-import type { EvaluationMetrics as Metrics } from "../types";
+import type { EvaluationResponse } from "../types";
 
 interface EvaluationMetricsProps {
-  metrics: Metrics;
+  evaluationResponse: EvaluationResponse;
 }
 
-type Rating = "Bad" | "Good" | "Excellent";
+// Blue color palette for progress bars
+const PROGRESS_BAR_COLOR = "#3b82f6"; // Primary blue
 
-const getRating = (value: number): Rating => {
-  const percentage = value * 100;
-  if (percentage >= 80) return "Excellent";
-  if (percentage >= 60) return "Good";
-  return "Bad";
-};
-
-const getRatingColor = (rating: Rating): string => {
-  switch (rating) {
-    case "Excellent":
-      return "#48bb78"; // green
-    case "Good":
-      return "#f6ad55"; // orange
-    case "Bad":
-      return "#fc8181"; // red
+const EvaluationMetrics = ({ evaluationResponse }: EvaluationMetricsProps) => {
+  const metrics = evaluationResponse.results[0];
+  
+  if (!metrics) {
+    return (
+      <div className="evaluation-container">
+        <p className="muted">No evaluation results available</p>
+      </div>
+    );
   }
-};
 
-const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
-  const precisionPercent = (metrics.precision_mean * 100).toFixed(1);
-  const recallPercent = (metrics.recall_mean * 100).toFixed(1);
-  const iouPercent = (metrics.iou_mean * 100).toFixed(1);
-  const precisionOmegaPercent = (metrics.precision_omega_mean * 100).toFixed(1);
+  const precisionValue = metrics.precision_mean.toFixed(3);
+  const recallValue = metrics.recall_mean.toFixed(3);
+  const iouValue = metrics.iou_mean.toFixed(3);
+  const precisionOmegaValue = metrics.precision_omega_mean.toFixed(3);
 
-  const overallRating = getRating(
-    (metrics.precision_mean +
-      metrics.recall_mean +
-      metrics.iou_mean +
-      metrics.precision_omega_mean) /
-      4
-  );
+  // For progress bar width, convert to percentage
+  const precisionPercent = metrics.precision_mean * 100;
+  const recallPercent = metrics.recall_mean * 100;
+  const iouPercent = metrics.iou_mean * 100;
+  const precisionOmegaPercent = metrics.precision_omega_mean * 100;
 
   return (
     <div className="evaluation-container">
@@ -47,16 +38,25 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
             Performance metrics for your chunking strategy
           </p>
         </div>
-        <span className={`rating-badge rating-${overallRating.toLowerCase()}`}>
-          {overallRating}
-        </span>
+      </div>
+
+      <div className="queries-info">
+        <p>
+          <strong>Queries S3 Path:</strong>{" "}
+          <code>{evaluationResponse.queries_s3_key}</code>
+        </p>
+        <p className="queries-status">
+          {evaluationResponse.queries_generated
+            ? `✓ New queries were generated${evaluationResponse.num_queries ? ` (${evaluationResponse.num_queries} queries)` : ""}`
+            : "✓ Existing queries were used"}
+        </p>
       </div>
 
       <div className="metrics-list">
         <div className="metric-item">
           <div className="metric-header">
             <span className="metric-name">Precision</span>
-            <span className="metric-value">{precisionPercent}%</span>
+            <span className="metric-value">{precisionValue}</span>
           </div>
           <p className="metric-description">Accuracy of retrieved chunks</p>
           <div className="progress-bar">
@@ -64,9 +64,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
               className="progress-fill"
               style={{
                 width: `${precisionPercent}%`,
-                backgroundColor: getRatingColor(
-                  getRating(metrics.precision_mean)
-                ),
+                backgroundColor: PROGRESS_BAR_COLOR,
               }}
             />
           </div>
@@ -75,7 +73,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
         <div className="metric-item">
           <div className="metric-header">
             <span className="metric-name">Precision Omega</span>
-            <span className="metric-value">{precisionOmegaPercent}%</span>
+            <span className="metric-value">{precisionOmegaValue}</span>
           </div>
           <p className="metric-description">Weighted precision metric</p>
           <div className="progress-bar">
@@ -83,9 +81,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
               className="progress-fill"
               style={{
                 width: `${precisionOmegaPercent}%`,
-                backgroundColor: getRatingColor(
-                  getRating(metrics.precision_omega_mean)
-                ),
+                backgroundColor: PROGRESS_BAR_COLOR,
               }}
             />
           </div>
@@ -94,7 +90,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
         <div className="metric-item">
           <div className="metric-header">
             <span className="metric-name">Recall</span>
-            <span className="metric-value">{recallPercent}%</span>
+            <span className="metric-value">{recallValue}</span>
           </div>
           <p className="metric-description">Coverage of relevant information</p>
           <div className="progress-bar">
@@ -102,7 +98,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
               className="progress-fill"
               style={{
                 width: `${recallPercent}%`,
-                backgroundColor: getRatingColor(getRating(metrics.recall_mean)),
+                backgroundColor: PROGRESS_BAR_COLOR,
               }}
             />
           </div>
@@ -111,7 +107,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
         <div className="metric-item">
           <div className="metric-header">
             <span className="metric-name">IoU</span>
-            <span className="metric-value">{iouPercent}%</span>
+            <span className="metric-value">{iouValue}</span>
           </div>
           <p className="metric-description">Intersection over Union score</p>
           <div className="progress-bar">
@@ -119,7 +115,7 @@ const EvaluationMetrics = ({ metrics }: EvaluationMetricsProps) => {
               className="progress-fill"
               style={{
                 width: `${iouPercent}%`,
-                backgroundColor: getRatingColor(getRating(metrics.iou_mean)),
+                backgroundColor: PROGRESS_BAR_COLOR,
               }}
             />
           </div>

--- a/client/src/components/TabView.tsx
+++ b/client/src/components/TabView.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
-
-export type Tab = "visualization" | "evaluation" | "deploy";
+import type { Tab } from "../types";
 
 interface TabViewProps {
   workflowId?: string;
@@ -13,7 +12,12 @@ interface TabViewProps {
   };
 }
 
-const TabView = ({ workflowId, hasEvaluation, switchToEvaluation = false, children }: TabViewProps) => {
+const TabView = ({
+  workflowId,
+  hasEvaluation,
+  switchToEvaluation = false,
+  children,
+}: TabViewProps) => {
   const [activeTab, setActiveTab] = useState<Tab>("visualization");
 
   // Reset to visualization
@@ -40,9 +44,7 @@ const TabView = ({ workflowId, hasEvaluation, switchToEvaluation = false, childr
           Visualization
         </button>
         <button
-          className={`tab-button ${
-            activeTab === "evaluation" ? "active" : ""
-          }`}
+          className={`tab-button ${activeTab === "evaluation" ? "active" : ""}`}
           onClick={() => setActiveTab("evaluation")}
           disabled={!hasEvaluation}
         >
@@ -59,8 +61,8 @@ const TabView = ({ workflowId, hasEvaluation, switchToEvaluation = false, childr
         {activeTab === "visualization"
           ? children.visualization
           : activeTab === "evaluation"
-            ? children.evaluation
-            : children.deploy}
+          ? children.evaluation
+          : children.deploy}
       </div>
     </div>
   );

--- a/client/src/components/TabView.tsx
+++ b/client/src/components/TabView.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export type Tab = "visualization" | "evaluation" | "deploy";
 
 interface TabViewProps {
+  workflowId?: string;
   hasEvaluation: boolean;
-  defaultTab?: Tab;
+  switchToEvaluation?: boolean;
   children: {
     visualization: React.ReactNode;
     evaluation: React.ReactNode;
@@ -12,8 +13,20 @@ interface TabViewProps {
   };
 }
 
-const TabView = ({ hasEvaluation, defaultTab = "visualization", children }: TabViewProps) => {
-  const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
+const TabView = ({ workflowId, hasEvaluation, switchToEvaluation = false, children }: TabViewProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>("visualization");
+
+  // Reset to visualization
+  useEffect(() => {
+    setActiveTab("visualization");
+  }, [workflowId]);
+
+  // Switch to evaluation
+  useEffect(() => {
+    if (switchToEvaluation) {
+      setActiveTab("evaluation");
+    }
+  }, [switchToEvaluation]);
 
   return (
     <div className="tab-view">

--- a/client/src/components/TabView.tsx
+++ b/client/src/components/TabView.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 
+export type Tab = "visualization" | "evaluation" | "deploy";
+
 interface TabViewProps {
   hasEvaluation: boolean;
+  defaultTab?: Tab;
   children: {
     visualization: React.ReactNode;
     evaluation: React.ReactNode;
@@ -9,10 +12,8 @@ interface TabViewProps {
   };
 }
 
-type Tab = "visualization" | "evaluation" | "deploy";
-
-const TabView = ({ hasEvaluation, children }: TabViewProps) => {
-  const [activeTab, setActiveTab] = useState<Tab>("visualization");
+const TabView = ({ hasEvaluation, defaultTab = "visualization", children }: TabViewProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
 
   return (
     <div className="tab-view">

--- a/client/src/components/WorkflowComparison.tsx
+++ b/client/src/components/WorkflowComparison.tsx
@@ -22,6 +22,9 @@ const EVALUATION_METRIC_KEYS: Record<keyof EvaluationMetrics, string> = {
   precision_omega_mean: "Precision omega mean",
 };
 
+// Blue color for progress bars
+const PROGRESS_BAR_COLOR = "#3b82f6";
+
 type Props = {
   chunkers: Chunker[];
   workflows: Workflow[];
@@ -61,13 +64,6 @@ const WorkflowComparison = ({ workflows, chunkers }: Props) => {
       .filter((value): value is string => Boolean(value));
 
     return configPairs.join(", ");
-  };
-
-  const getRatingColor = (value: number): string => {
-    const percentage = value * 100;
-    if (percentage >= 80) return "#48bb78"; // green
-    if (percentage >= 60) return "#f6ad55"; // orange
-    return "#fc8181"; // red
   };
 
   return (
@@ -166,10 +162,10 @@ const WorkflowComparison = ({ workflows, chunkers }: Props) => {
                     <h4 className="comparison-section-title">
                       Evaluation Results
                     </h4>
-                    {workflow.evaluation_metrics ? (
+                    {workflow.evaluation_response?.results?.[0] ? (
                       (() => {
                         const metrics =
-                          workflow.evaluation_metrics as EvaluationMetrics;
+                          workflow.evaluation_response.results[0] as EvaluationMetrics;
                         return (
                           <div className="comparison-evaluation">
                             {(
@@ -198,7 +194,7 @@ const WorkflowComparison = ({ workflows, chunkers }: Props) => {
                                       className="comparison-progress-fill"
                                       style={{
                                         width: `${width}%`,
-                                        backgroundColor: getRatingColor(value),
+                                        backgroundColor: PROGRESS_BAR_COLOR,
                                       }}
                                     />
                                   </div>

--- a/client/src/components/WorkflowDetails.tsx
+++ b/client/src/components/WorkflowDetails.tsx
@@ -3,7 +3,7 @@ import { ZodError } from "zod";
 import type { Workflow, Chunker } from "../types";
 import ChooseFile from "./ChooseFile";
 import ChunkerForm from "./ChunkerForm";
-import TabView, { type Tab } from "./TabView";
+import TabView from "./TabView";
 import EvaluationMetrics from "./EvaluationMetrics";
 import ChunkStats from "./ChunkStats";
 import VisualizationDisplay from "./VisualizationDisplay";
@@ -35,14 +35,8 @@ const WorkflowDetails = ({
   );
   const [isLoadingViz, setIsLoadingViz] = useState(false);
   const [isEvaluating, setIsEvaluating] = useState(false);
+  const [switchToEvaluation, setSwitchToEvaluation] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Track default tab - changes to "evaluation" after evaluation completes
-  const [defaultTab, setDefaultTab] = useState<Tab>("visualization");
-  // Counter to force TabView remount (incremented on evaluation completion)
-  const [tabResetCounter, setTabResetCounter] = useState(0);
-  
-  // Key combines workflow ID and counter - workflow change resets to viz, counter change after eval switches to eval tab
-  const tabKey = `${workflow?.id ?? "none"}-${tabResetCounter}`;
 
   // Cleanup timer on unmount
   useEffect(() => {
@@ -52,12 +46,6 @@ const WorkflowDetails = ({
       }
     };
   }, [configChangeTimer]);
-
-  // Reset to visualization tab when workflow changes
-  useEffect(() => {
-    setDefaultTab("visualization");
-    setTabResetCounter(0);
-  }, [workflow?.id]);
 
   // Sync local config with workflow changes
   useEffect(() => {
@@ -150,7 +138,7 @@ const WorkflowDetails = ({
     }
   }
 
-  // Handlers for chunker and config change
+  // Handler for chunker change
   async function handleChunkerChange(name: string) {
     setError(null);
     try {
@@ -180,6 +168,7 @@ const WorkflowDetails = ({
     }
   }
 
+  // Handler for config change
   async function handleConfigChange(key: string, value: number) {
     if (!workflow?.chunking_strategy) return;
     setError(null);
@@ -224,9 +213,7 @@ const WorkflowDetails = ({
       await onPatchWorkflow({
         evaluation_response: evaluationResponse,
       });
-      // Switch to evaluation tab when data loads by remounting TabView with new default
-      setDefaultTab("evaluation");
-      setTabResetCounter((c) => c + 1);
+      setSwitchToEvaluation(true);
     } catch (error: unknown) {
       console.error("Failed to run evaluation:", error);
       if (error instanceof ZodError) {
@@ -301,10 +288,10 @@ const WorkflowDetails = ({
             </button>
           </div>
 
-          <TabView 
-            key={tabKey}
+          <TabView
+            workflowId={workflow.id}
             hasEvaluation={!!workflow.evaluation_response}
-            defaultTab={defaultTab}
+            switchToEvaluation={switchToEvaluation}
           >
             {{
               visualization: (
@@ -332,7 +319,9 @@ const WorkflowDetails = ({
                 </div>
               ),
               evaluation: workflow.evaluation_response ? (
-                <EvaluationMetrics evaluationResponse={workflow.evaluation_response} />
+                <EvaluationMetrics
+                  evaluationResponse={workflow.evaluation_response}
+                />
               ) : (
                 <div className="tab-panel">
                   <p className="muted">

--- a/client/src/components/WorkflowDetails.tsx
+++ b/client/src/components/WorkflowDetails.tsx
@@ -3,7 +3,7 @@ import { ZodError } from "zod";
 import type { Workflow, Chunker } from "../types";
 import ChooseFile from "./ChooseFile";
 import ChunkerForm from "./ChunkerForm";
-import TabView from "./TabView";
+import TabView, { type Tab } from "./TabView";
 import EvaluationMetrics from "./EvaluationMetrics";
 import ChunkStats from "./ChunkStats";
 import VisualizationDisplay from "./VisualizationDisplay";
@@ -36,6 +36,13 @@ const WorkflowDetails = ({
   const [isLoadingViz, setIsLoadingViz] = useState(false);
   const [isEvaluating, setIsEvaluating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Track default tab - changes to "evaluation" after evaluation completes
+  const [defaultTab, setDefaultTab] = useState<Tab>("visualization");
+  // Counter to force TabView remount (incremented on evaluation completion)
+  const [tabResetCounter, setTabResetCounter] = useState(0);
+  
+  // Key combines workflow ID and counter - workflow change resets to viz, counter change after eval switches to eval tab
+  const tabKey = `${workflow?.id ?? "none"}-${tabResetCounter}`;
 
   // Cleanup timer on unmount
   useEffect(() => {
@@ -45,6 +52,12 @@ const WorkflowDetails = ({
       }
     };
   }, [configChangeTimer]);
+
+  // Reset to visualization tab when workflow changes
+  useEffect(() => {
+    setDefaultTab("visualization");
+    setTabResetCounter(0);
+  }, [workflow?.id]);
 
   // Sync local config with workflow changes
   useEffect(() => {
@@ -207,10 +220,13 @@ const WorkflowDetails = ({
     setError(null);
 
     try {
-      const metrics = await getEvaluationMetrics(workflow.id);
+      const evaluationResponse = await getEvaluationMetrics(workflow.id);
       await onPatchWorkflow({
-        evaluation_metrics: metrics,
+        evaluation_response: evaluationResponse,
       });
+      // Switch to evaluation tab when data loads by remounting TabView with new default
+      setDefaultTab("evaluation");
+      setTabResetCounter((c) => c + 1);
     } catch (error: unknown) {
       console.error("Failed to run evaluation:", error);
       if (error instanceof ZodError) {
@@ -285,7 +301,11 @@ const WorkflowDetails = ({
             </button>
           </div>
 
-          <TabView hasEvaluation={!!workflow.evaluation_metrics}>
+          <TabView 
+            key={tabKey}
+            hasEvaluation={!!workflow.evaluation_response}
+            defaultTab={defaultTab}
+          >
             {{
               visualization: (
                 <div className="tab-panel">
@@ -311,8 +331,8 @@ const WorkflowDetails = ({
                   ) : null}
                 </div>
               ),
-              evaluation: workflow.evaluation_metrics ? (
-                <EvaluationMetrics metrics={workflow.evaluation_metrics} />
+              evaluation: workflow.evaluation_response ? (
+                <EvaluationMetrics evaluationResponse={workflow.evaluation_response} />
               ) : (
                 <div className="tab-panel">
                   <p className="muted">

--- a/client/src/components/WorkflowDetails.tsx
+++ b/client/src/components/WorkflowDetails.tsx
@@ -4,12 +4,12 @@ import type { Workflow, Chunker } from "../types";
 import ChooseFile from "./ChooseFile";
 import ChunkerForm from "./ChunkerForm";
 import TabView from "./TabView";
-import EvaluationMetrics from "./EvaluationMetrics";
 import ChunkStats from "./ChunkStats";
 import VisualizationDisplay from "./VisualizationDisplay";
+import Evaluation from "./Evaluation";
 import DeployConnector from "./DeployConnector";
 import { getVisualization } from "../services/visualization";
-import { getEvaluationMetrics } from "../services/evaluation";
+import { getEvaluation } from "../services/evaluation";
 
 type Props = {
   chunkers: Chunker[];
@@ -209,7 +209,7 @@ const WorkflowDetails = ({
     setError(null);
 
     try {
-      const evaluationResponse = await getEvaluationMetrics(workflow.id);
+      const evaluationResponse = await getEvaluation(workflow.id);
       await onPatchWorkflow({
         evaluation_response: evaluationResponse,
       });
@@ -319,9 +319,7 @@ const WorkflowDetails = ({
                 </div>
               ),
               evaluation: workflow.evaluation_response ? (
-                <EvaluationMetrics
-                  evaluationResponse={workflow.evaluation_response}
-                />
+                <Evaluation evaluationResponse={workflow.evaluation_response} />
               ) : (
                 <div className="tab-panel">
                   <p className="muted">

--- a/client/src/reducers/workflowReducer.ts
+++ b/client/src/reducers/workflowReducer.ts
@@ -20,7 +20,7 @@ export type Action =
   | { type: "DELETE_WORKFLOW"; payload: string };
 
 export const computeWorkflowStage = (workflow: Workflow): Stage => {
-  if (workflow.evaluation_metrics) {
+  if (workflow.evaluation_response) {
     return "Evaluated";
   }
   if (workflow.chunking_strategy) {

--- a/client/src/services/evaluation.ts
+++ b/client/src/services/evaluation.ts
@@ -1,7 +1,7 @@
 // import axios from "axios";
 // import { EvaluationResponseSchema, type EvaluationResponse } from "../types";
 
-// export const getEvaluationMetrics = async (
+// export const getEvaluation = async (
 //   workflowId: string
 // ): Promise<EvaluationResponse> => {
 //   const response = await axios.get(`/api/workflows/${workflowId}/evaluation`);
@@ -10,7 +10,7 @@
 
 // For local testing on Saurabh's machine
 import { type EvaluationResponse } from "../types";
-export const getEvaluationMetrics = async (
+export const getEvaluation = async (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _workflowId: string
 ): Promise<EvaluationResponse> => {

--- a/client/src/services/evaluation.ts
+++ b/client/src/services/evaluation.ts
@@ -20,7 +20,7 @@ export const getEvaluation = async (
     corpus_id: "corpus-12345",
     document_s3_key: "documents/sample-doc.pdf",
     queries_s3_key:
-      "s3://chunkwise-bucket/queries/generated-queries-12345.json",
+      "queries/generated-queries-12345.json",
     queries_generated: true,
     num_queries: 50,
     chunkers_evaluated: ["langchain recursive"],

--- a/client/src/services/evaluation.ts
+++ b/client/src/services/evaluation.ts
@@ -1,24 +1,35 @@
 // import axios from "axios";
-// import { EvaluationMetricsSchema, type EvaluationMetrics } from "../types";
+// import { EvaluationResponseSchema, type EvaluationResponse } from "../types";
 
 // export const getEvaluationMetrics = async (
 //   workflowId: string
-// ): Promise<EvaluationMetrics> => {
+// ): Promise<EvaluationResponse> => {
 //   const response = await axios.get(`/api/workflows/${workflowId}/evaluation`);
-//   return EvaluationMetricsSchema.parse(response.data);
+//   return EvaluationResponseSchema.parse(response.data);
 // };
 
 // For local testing on Saurabh's machine
-import { type EvaluationMetrics } from "../types";
+import { type EvaluationResponse } from "../types";
 export const getEvaluationMetrics = async (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _workflowId: string
-): Promise<EvaluationMetrics> => {
+): Promise<EvaluationResponse> => {
   await new Promise((resolve) => setTimeout(resolve, 1500));
   return {
-    precision_mean: 0.708,
-    recall_mean: 0.715,
-    iou_mean: 0.65,
-    precision_omega_mean: 0.725,
+    embedding_model: "text-embedding-ada-002",
+    corpus_id: "corpus-12345",
+    document_s3_key: "documents/sample-doc.pdf",
+    queries_s3_key: "s3://chunkwise-bucket/queries/generated-queries-12345.json",
+    queries_generated: true,
+    num_queries: 50,
+    chunkers_evaluated: ["langchain recursive"],
+    results: [
+      {
+        precision_mean: 0.708,
+        recall_mean: 0.715,
+        iou_mean: 0.65,
+        precision_omega_mean: 0.725,
+      },
+    ],
   };
 };

--- a/client/src/services/evaluation.ts
+++ b/client/src/services/evaluation.ts
@@ -19,7 +19,8 @@ export const getEvaluationMetrics = async (
     embedding_model: "text-embedding-ada-002",
     corpus_id: "corpus-12345",
     document_s3_key: "documents/sample-doc.pdf",
-    queries_s3_key: "s3://chunkwise-bucket/queries/generated-queries-12345.json",
+    queries_s3_key:
+      "s3://chunkwise-bucket/queries/generated-queries-12345.json",
     queries_generated: true,
     num_queries: 50,
     chunkers_evaluated: ["langchain recursive"],

--- a/client/src/services/workflows.ts
+++ b/client/src/services/workflows.ts
@@ -12,7 +12,7 @@ const parseWorkflowFields = (workflow: Record<string, unknown>): Workflow => {
   const jsonFields = [
     "chunking_strategy",
     "chunks_stats",
-    "evaluation_metrics",
+    "evaluation_response",
   ] as const;
 
   for (const key of jsonFields) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -657,6 +657,38 @@ html,
   color: #2d3748;
 }
 
+.queries-info {
+  background: #f0f7ff;
+  padding: 16px;
+  border-radius: 6px;
+  margin-bottom: 24px;
+  border: 1px solid #bfdbfe;
+}
+
+.queries-info p {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  color: #1e40af;
+}
+
+.queries-info p:last-child {
+  margin-bottom: 0;
+}
+
+.queries-info code {
+  background: #dbeafe;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.queries-status {
+  font-weight: 500;
+  color: #1d4ed8;
+}
+
 /* Workflow Comparison */
 .comparison-view {
   display: flex;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-export const StageSchema = z.enum(["Draft", "Configured", "Evaluated"]);
+export type Stage = "Draft" | "Configured" | "Evaluated";
 
-export type Stage = z.infer<typeof StageSchema>;
+export type Tab = "visualization" | "evaluation" | "deploy";
 
 export interface File {
   document_title: string;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -65,6 +65,19 @@ export const EvaluationMetricsSchema = z.object({
 
 export type EvaluationMetrics = z.infer<typeof EvaluationMetricsSchema>;
 
+export const EvaluationResponseSchema = z.object({
+  embedding_model: z.string(),
+  corpus_id: z.string(),
+  document_s3_key: z.string(),
+  queries_s3_key: z.string(),
+  queries_generated: z.boolean(),
+  num_queries: z.number().nullable().optional(),
+  chunkers_evaluated: z.array(z.string()),
+  results: z.array(EvaluationMetricsSchema),
+});
+
+export type EvaluationResponse = z.infer<typeof EvaluationResponseSchema>;
+
 export const WorkflowResponseSchema = z.object({
   id: z.union([z.string(), z.number()]).transform((value) => String(value)),
   title: z.string(),
@@ -78,8 +91,8 @@ export const WorkflowResponseSchema = z.object({
     .union([ChunkStatisticsSchema, z.string(), z.null()])
     .optional(),
   visualization_html: z.string().optional().nullable(),
-  evaluation_metrics: z
-    .union([EvaluationMetricsSchema, z.string(), z.null()])
+  evaluation_response: z
+    .union([EvaluationResponseSchema, z.string(), z.null()])
     .optional(),
 });
 
@@ -92,5 +105,5 @@ export interface Workflow {
   chunking_strategy?: ChunkingStrategy;
   chunks_stats?: ChunkStatistics;
   visualization_html?: string | null;
-  evaluation_metrics?: EvaluationMetrics;
+  evaluation_response?: EvaluationResponse;
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,16 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      "/api": {
-        target: "http://chunkwise-alb-1341063601.us-east-1.elb.amazonaws.com",
-        changeOrigin: true,
-        secure: false,
-      },
+      "/api": process.env.ALB_URI
+        ? `http://${process.env.ALB_URI}`
+        : "http://localhost:8000",
     },
   },
 });


### PR DESCRIPTION
This PR includes the preliminary changes that need to be made to the evaluation component:
- Shows if existing queries were used or new queries were generated.
- Shows the number of queries generated.
- Shows floats instead of percent, and the color of the bar is set to a neutral color (Blue)
- Removes the judgement tag.
- Includes the change made to vite config by @b3nbino 