### PR TITLE
Optimize CDK/CLI for default production mode

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -11,7 +11,7 @@ This CDK application automates the production deployment of Chunkwise, a documen
 
 ### Production Mode (Default - Current Configuration)
 
-- ✅ Databases and S3 are **RETAINED** on stack deletion (data protection)
+- ✅ Databases and S3 are **RETAINED** on deletion of the Database and ECS stacks for data protection
 - ✅ Deletion protection enabled on databases
 - ⚠️ Retained resources continue to incur costs
 - ⚠️ Manual cleanup required when fully decommissioning
@@ -143,7 +143,7 @@ ENVIRONMENT = "production"  # Default - retains data on deletion
 # ENVIRONMENT = "development"  # Destroys all resources on deletion
 ```
 
-**Resource sizes:**
+**Resource allocation and configuration:**
 
 - Default configuration uses AWS Free Tier eligible resources
 - For production workloads, consider upgrading instance types
@@ -247,7 +247,7 @@ cdk deploy --all --dry-run
 
 ## Updating the Deployment
 
-**Recommended for Production Environment: Update in place**
+**Recommended for production environment: Update in place**
 
 ```bash
 cdk deploy --all
@@ -290,7 +290,7 @@ These stacks can be destroyed and redeployed as needed without data loss.
 
 #### For routine teardowns or redeployments:
 
-1. Destroy the application stacks
+1. Destroy the application stacks in the following order
 
 ```bash
 # Destroy ECS stack first
@@ -309,8 +309,8 @@ To redeploy, run `cdk deploy --all`
 
 3. Manually delete retained data resources via AWS Console
 
-- Disable "deletion protection" for RDS instances
-- Delete RDS instances
+- Disable "deletion protection" for both RDS instances (evaluation + production)
+- Delete both RDS instances
 - Delete the S3 bucket (chunkwise-\*)
 
 4. Delete database credentials and OpenAI API key in Secrets Manager

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -331,7 +331,7 @@ aws secretsmanager delete-secret \
 5. Destroy foundation stacks
 
 ```bash
-# Now destroy the database stack (resources already manually deleted)
+# Now destroy the data stack (resources already manually deleted)
 cdk destroy ChunkwiseDataStack
 
 # Finally destroy the network stack

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -5,7 +5,7 @@ This CDK application automates the production deployment of Chunkwise, a documen
 ⚠️ **Important - Production Configuration** ⚠️:
 
 - The application is configured for **PRODUCTION** by default, where databases and S3 bucket have `RemovalPolicy.RETAIN` to prevent accidental data loss. On stack deletion, these resources will be **RETAINED** and continue to incur costs. Manual cleanup is required for full decommission.
-- For **DEVELOPMENT/TESTING**, change `ENVIRONMENT = "development"` in `config.py` to enable automatic cleanup.
+- For **DEVELOPMENT/TESTING**, set `ENVIRONMENT = "development"` in `config.py` to enable automatic cleanup.
 
 ## Environment Modes
 
@@ -266,49 +266,77 @@ This updates existing resources without destroying data.
 
 ### Current Configuration: Production Mode
 
-When you destroy the stack in production mode:
+When you destroy stacks in production mode, resources are separated into two categories:
 
-❌ **These resources will be RETAINED** (continue to incur costs):
+#### ✅ **Application Stacks** (Safe to Destroy - Automatically Removed)
 
-- RDS PostgreSQL databases (evaluation + production)
-- S3 bucket with documents and queries
-- Database credentials in Secrets Manager
+- **ECS Stack**: ECS services, tasks, and cluster
+- **Load Balancer Stack**: Application Load Balancer and target groups
+- **Batch Stack**: AWS Batch compute environment, job queues, and job definitions
+- CloudWatch log groups (depending on retention settings)
 
-### Destruction Steps
+These stacks can be destroyed and redeployed as needed without data loss.
 
-1. Destroy stacks in the following order:
+#### ❌ **Foundation Stacks** (RETAINED - Manual Cleanup Required)
+
+- **Network Stack**: VPC, subnets, NAT gateways, internet gateway, route tables
+- **Database Stack**: RDS instances (evaluation + production), DB subnet groups, DB security groups
+- S3 Bucket: Documents and queries storage (chunkwise-\*)
+- Secrets: Database credentials, OpenAI API key
+
+**These resources will continue to incur costs after stack destruction.**
+
+### Destruction Steps (Production Mode)
+
+#### For routine teardowns or redeployments:
+
+1. Destroy the application stacks
 
 ```bash
-# 1. Destroy ECS stack first
+# Destroy ECS stack first
 cdk destroy ChunkwiseEcsStack
 
-# 2. Destroy other stacks
+# Destroy Load Balancer and Batch stacks
+cdk destroy ChunkwiseLoadBalancerStack
+cdk destroy ChunkwiseBatchStack
+```
+
+To redeploy, run `cdk deploy --all`
+
+#### For complete cleanup, continue with the following steps
+
+2. Before destroying fundation stacks, export or back up data
+
+3. Manually delete retained data resources via AWS Console
+
+- Disable "deletion protection" for RDS instances
+- Delete RDS instances
+- Delete the S3 bucket (chunkwise-\*)
+
+4. Delete database credentials and OpenAI API key in Secrets Manager
+
+5. Destroy foundation stacks
+
+```bash
+# Now destroy the database stack (resources already manually deleted)
+cdk destroy ChunkwiseDatabaseStack
+
+# Finally destroy the network stack
+cdk destroy ChunkwiseNetworkStack
+```
+
+### Destruction Steps (Development Mode)
+
+If you're running in development mode (`ENVIRONMENT = "development"` in `config.py`):
+
+1. Destroy the stacks in the following order
+
+```bash
+# Destroy ECS stack first
+cdk destroy ChunkwiseEcsStack
+
+# Destroy all other stacks
 cdk destroy --all
 ```
 
-In development mode, cleanup is complete after this step.
-
-In production mode, continue with the following steps.
-
-2. List retained resources
-
-After destruction, verify what was retained:
-
-```bash
-# List RDS instances
-aws rds describe-db-instances \
-  --query 'DBInstances[?contains(DBInstanceIdentifier, `chunkwise`)].{Name:DBInstanceIdentifier,Status:DBInstanceStatus,Size:AllocatedStorage}' \
-  --output table
-
-# List S3 buckets
-aws s3 ls | grep chunkwise
-
-# List secrets
-aws secretsmanager list-secrets \
-  --query 'SecretList[?contains(Name, `chunkwise`)].Name' \
-  --output table
-```
-
-3. Export/backup all data to avoid data loss
-
-4. Manually clean up retained resources via AWS Console
+2. Manually destroy the OpenAI API key in Secrets Manager as it's not managed by the CDK app

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,6 +1,6 @@
 # Chunkwise CDK Deployment
 
-This CDK application automates the production deployment of Chunkwise, a document chunking evaluation platform and a RAG data ingestion pipeline, to AWS.
+This CDK application automates the deployment of Chunkwise, a document chunking evaluation platform and a RAG data ingestion pipeline, to AWS.
 
 ⚠️ **Important - Production Configuration** ⚠️:
 

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -26,7 +26,7 @@ This CDK application automates the deployment of Chunkwise, a document chunking 
 
 The deployment creates:
 
-**Chunking evaluation platform**
+**Chunking Experimentation Platform**
 
 - **VPC**: Custom VPC with public and private subnets across 2 availability zones
 - **ECS Fargate**: Three containerized microservices (server, chunking, evaluation)

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -314,6 +314,20 @@ To redeploy, run `cdk deploy --all`
 
 4. Delete database credentials and OpenAI API key in Secrets Manager
 
+```bash
+aws secretsmanager delete-secret \
+  --secret-id chunkwise/db-credentials \
+  --force-delete-without-recovery
+
+aws secretsmanager delete-secret \
+  --secret-id chunkwise/production-db-credentials \
+  --force-delete-without-recovery
+
+aws secretsmanager delete-secret \
+  --secret-id chunkwise/openai-api-key \
+  --force-delete-without-recovery
+```
+
 5. Destroy foundation stacks
 
 ```bash

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -304,7 +304,7 @@ To redeploy, run `cdk deploy --all`
 
 #### For complete cleanup, continue with the following steps
 
-2. Before destroying fundation stacks, export or back up data
+2. Before destroying foundation stacks, export or back up data
 
 3. Manually delete retained data resources via AWS Console
 

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -4,14 +4,14 @@ This CDK application automates the production deployment of Chunkwise, a documen
 
 ⚠️ **Important - Production Configuration** ⚠️:
 
-- The application is configured for **PRODUCTION** by default, where databases and S3 bucket have `RemovalPolicy.RETAIN` to prevent accidental data loss. On stack deletion, these resources will be **RETAINED** and continue to incur costs. Manual cleanup is required for full decommission.
+- The application is configured for **PRODUCTION** by default, where databases and S3 bucket have `RemovalPolicy.RETAIN` to prevent accidental data loss. On data stack deletion, these resources will be **RETAINED** and continue to incur costs. Manual cleanup is required for full decommission.
 - For **DEVELOPMENT/TESTING**, set `ENVIRONMENT = "development"` in `config.py` to enable automatic cleanup.
 
 ## Environment Modes
 
 ### Production Mode (Default - Current Configuration)
 
-- ✅ Databases and S3 are **RETAINED** on deletion of the Database and ECS stacks for data protection
+- ✅ Databases and S3 are **RETAINED** on deletion of the Data stack for data protection
 - ✅ Deletion protection enabled on databases
 - ⚠️ Retained resources continue to incur costs
 - ⚠️ Manual cleanup required when fully decommissioning
@@ -31,8 +31,8 @@ The deployment creates:
 - **VPC**: Custom VPC with public and private subnets across 2 availability zones
 - **ECS Fargate**: Three containerized microservices (server, chunking, evaluation)
 - **RDS PostgreSQL**: Relational database that stores chunking visualization and evaluation results
-- **Application Load Balancer**: Routes external traffic to the server service
 - **S3**: Stores documents to evaluate and LLM-generated queries
+- **Application Load Balancer**: Routes external traffic to the server service
 - **AWS Cloud Map**: Service discovery for inter-service communication
 
 **RAG Data Ingestion Pipeline**
@@ -172,8 +172,8 @@ This will deploy all four stacks:
 
 1. `ChunkwiseNetworkStack` - VPC with public/private subnets across 2 availability zones, NAT gateways, Internet gateway
 2. `ChunkwiseLoadBalancerStack` - Application Load Balancer, target group, and security group
-3. `ChunkwiseDatabaseStack` - Two RDS PostgreSQL instances (evaluation + production with pgvector), subnet group, security groups, Secrets Manager secrets for credentials
-4. `ChunkwiseEcsStack` - ECS cluster, 3 services (server, chunking, evaluation), Cloud Map, S3 bucket, IAM roles, CloudWatch log groups, security groups, Secrets Manager secrets for API key
+3. `ChunkwiseDataStack` - 2 RDS PostgreSQL instances (evaluation + production with pgvector), subnet group, security groups, Secrets Manager secrets for database credentials, 1 S3 bucket
+4. `ChunkwiseEcsStack` - ECS cluster, 3 services (server, chunking, evaluation), Cloud Map, IAM roles, CloudWatch log groups, security groups, Secrets Manager secrets for API key
 5. `ChunkwiseBatchStack` - AWS Batch compute environment, job queue, job definition, IAM roles
 
 ### Option 2: Deploy Stacks Individually
@@ -181,7 +181,7 @@ This will deploy all four stacks:
 ```bash
 cdk deploy ChunkwiseNetworkStack
 cdk deploy ChunkwiseLoadBalancerStack
-cdk deploy ChunkwiseDatabaseStack
+cdk deploy ChunkwiseDataStack
 cdk deploy ChunkwiseEcsStack
 cdk deploy ChunkwiseBatchStack
 ```
@@ -280,8 +280,7 @@ These stacks can be destroyed and redeployed as needed without data loss.
 #### ❌ **Foundation Stacks** (RETAINED - Manual Cleanup Required)
 
 - **Network Stack**: VPC, subnets, NAT gateways, internet gateway, route tables
-- **Database Stack**: RDS instances (evaluation + production), DB subnet groups, DB security groups
-- S3 Bucket: Documents and queries storage (chunkwise-\*)
+- **Data Stack**: RDS instances (evaluation + production), DB subnet groups, DB security groups, S3 bucket
 - Secrets: Database credentials, OpenAI API key
 
 **These resources will continue to incur costs after stack destruction.**
@@ -319,7 +318,7 @@ To redeploy, run `cdk deploy --all`
 
 ```bash
 # Now destroy the database stack (resources already manually deleted)
-cdk destroy ChunkwiseDatabaseStack
+cdk destroy ChunkwiseDataStack
 
 # Finally destroy the network stack
 cdk destroy ChunkwiseNetworkStack

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -274,8 +274,6 @@ When you destroy the stack in production mode:
 - S3 bucket with documents and queries
 - Database credentials in Secrets Manager
 
-Manually delete them when fully decommissioning.
-
 ### Destruction Steps
 
 1. Destroy stacks in the following order:
@@ -287,6 +285,10 @@ cdk destroy ChunkwiseEcsStack
 # 2. Destroy other stacks
 cdk destroy --all
 ```
+
+In development mode, cleanup is complete after this step.
+
+In production mode, continue with the following steps.
 
 2. List retained resources
 
@@ -307,4 +309,6 @@ aws secretsmanager list-secrets \
   --output table
 ```
 
-3. Manually clean up retained resources
+3. Export/backup all data to avoid data loss
+
+4. Manually clean up retained resources via AWS Console

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -5,7 +5,22 @@ This CDK application automates the production deployment of Chunkwise, a documen
 ⚠️ **Important - Production Configuration** ⚠️:
 
 - The application is configured for **PRODUCTION** by default, where databases and S3 bucket have `RemovalPolicy.RETAIN` to prevent accidental data loss. On stack deletion, these resources will be **RETAINED** and continue to incur costs. Manual cleanup is required for full decommission.
-- For **DEVELOPMENT/TESTING**, update the two RDS instances in `database_stack.py` and the S3 bucket in `ecs_stack.py` to have `RemovalPolicy.DESTROY` for automatic cleanup on stack deletion.
+- For **DEVELOPMENT/TESTING**, change `ENVIRONMENT = "development"` in `config.py` to enable automatic cleanup.
+
+## Environment Modes
+
+### Production Mode (Default - Current Configuration)
+
+- ✅ Databases and S3 are **RETAINED** on stack deletion (data protection)
+- ✅ Deletion protection enabled on databases
+- ⚠️ Retained resources continue to incur costs
+- ⚠️ Manual cleanup required when fully decommissioning
+
+### Development Mode
+
+- ✅ Resources are **DESTROYED** on stack deletion (clean teardown)
+- ✅ Lower costs, easy iteration, no orphaned resources
+- 🔧 Set `ENVIRONMENT = "development"` in `config.py` before deployment
 
 ## Architecture Overview
 
@@ -61,20 +76,33 @@ git clone https://github.com/Chunkwise/chunkwise_local.git
 cd chunkwise_local/cdk
 ```
 
-### 2. Create Python Virtual Environment
+### 2. Configure Environment Mode
+
+**For production deployment (default):**
+
+- No changes needed - already configured for production
+
+**For development/testing:**
+
+```python
+# Edit config.py
+ENVIRONMENT = "development"  # Change from "production"
+```
+
+### 3. Create Python Virtual Environment
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate.bat
 ```
 
-### 3. Install Dependencies
+### 4. Install Dependencies
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### 4. Bootstrap CDK (First Time Only)
+### 5. Bootstrap CDK (First Time Only)
 
 If this is your first time using CDK in your AWS account/region:
 
@@ -88,7 +116,7 @@ Example:
 cdk bootstrap aws://123456789012/us-west-2
 ```
 
-### 5. Store OpenAI API Key in Secrets Manager
+### 6. Store OpenAI API Key in Secrets Manager
 
 **This is the only manual setup required!**
 
@@ -106,7 +134,14 @@ aws secretsmanager describe-secret \
     --secret-id chunkwise/openai-api-key \
 ```
 
-### 6. Review and Adjust Configuration in `config.py`
+### 7. Review `config.py` and Adjust Configuration
+
+**Environment setting:**
+
+```python
+ENVIRONMENT = "production"  # Default - retains data on deletion
+# ENVIRONMENT = "development"  # Destroys all resources on deletion
+```
 
 **Resource sizes:**
 
@@ -212,7 +247,7 @@ cdk deploy --all --dry-run
 
 ## Updating the Deployment
 
-**Recommended for production: Update in place**
+**Recommended for Production Environment: Update in place**
 
 ```bash
 cdk deploy --all
@@ -227,7 +262,7 @@ This updates existing resources without destroying data.
 
 ## Destroying the Deployment
 
-**⚠️ Warning: Destruction behavior depends on your deployment environment**
+**⚠️ Warning: Destruction behavior depends on your environment configuration**
 
 ### Current Configuration: Production Mode
 
@@ -239,7 +274,11 @@ When you destroy the stack in production mode:
 - S3 bucket with documents and queries
 - Database credentials in Secrets Manager
 
-### Destroy Stacks in the Following Order
+Manually delete them when fully decommissioning.
+
+### Destruction Steps
+
+1. Destroy stacks in the following order:
 
 ```bash
 # 1. Destroy ECS stack first
@@ -248,4 +287,24 @@ cdk destroy ChunkwiseEcsStack
 # 2. Destroy other stacks
 cdk destroy --all
 ```
-### Manual
+
+2. List retained resources
+
+After destruction, verify what was retained:
+
+```bash
+# List RDS instances
+aws rds describe-db-instances \
+  --query 'DBInstances[?contains(DBInstanceIdentifier, `chunkwise`)].{Name:DBInstanceIdentifier,Status:DBInstanceStatus,Size:AllocatedStorage}' \
+  --output table
+
+# List S3 buckets
+aws s3 ls | grep chunkwise
+
+# List secrets
+aws secretsmanager list-secrets \
+  --query 'SecretList[?contains(Name, `chunkwise`)].Name' \
+  --output table
+```
+
+3. Manually clean up retained resources

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,13 +1,18 @@
-
 # Chunkwise CDK Deployment
 
-This CDK application automates the deployment of Chunkwise, a document chunking evaluation platform and a RAG data ingestion pipeline, to AWS.
+This CDK application automates the production deployment of Chunkwise, a document chunking evaluation platform and a RAG data ingestion pipeline, to AWS.
+
+⚠️ **Important - Production Configuration** ⚠️:
+
+- The application is configured for **PRODUCTION** by default, where databases and S3 bucket have `RemovalPolicy.RETAIN` to prevent accidental data loss. On stack deletion, these resources will be **RETAINED** and continue to incur costs. Manual cleanup is required for full decommission.
+- For **DEVELOPMENT/TESTING**, update the two RDS instances in `database_stack.py` and the S3 bucket in `ecs_stack.py` to have `RemovalPolicy.DESTROY` for automatic cleanup on stack deletion.
 
 ## Architecture Overview
 
 The deployment creates:
 
 **Chunking evaluation platform**
+
 - **VPC**: Custom VPC with public and private subnets across 2 availability zones
 - **ECS Fargate**: Three containerized microservices (server, chunking, evaluation)
 - **RDS PostgreSQL**: Relational database that stores chunking visualization and evaluation results
@@ -16,9 +21,10 @@ The deployment creates:
 - **AWS Cloud Map**: Service discovery for inter-service communication
 
 **RAG Data Ingestion Pipeline**
+
 - **AWS Batch**: On-demand document processing for production deployments, which uses
 - **Fargate compute environment** to process documents in parallel:
-    Normalizes, chunks, and embeds documents into vector database
+  Normalizes, chunks, and embeds documents into vector database
 - **RDS PostgreSQL with pgvector**: Vector database that stores chunked documents and embeddings for deployed workflows using a specific chunking strategy
 
 - **CloudWatch**: Centralized logging for monitoring all services
@@ -27,6 +33,7 @@ The deployment creates:
 Before deploying, make sure you have:
 
 1. **AWS CLI** configured with appropriate credentials
+
 ```bash
    aws configure
 ```
@@ -36,6 +43,7 @@ Before deploying, make sure you have:
 4. **Node.js 22.x+ and npm** installed
 
 5. **AWS CDK** installed globally
+
 ```bash
    npm install -g aws-cdk
 ```
@@ -47,18 +55,21 @@ Before deploying, make sure you have:
 ## Initial Setup
 
 ### 1. Clone the Repository
+
 ```bash
 git clone https://github.com/Chunkwise/chunkwise_local.git
 cd chunkwise_local/cdk
 ```
 
 ### 2. Create Python Virtual Environment
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate.bat
 ```
 
 ### 3. Install Dependencies
+
 ```bash
 pip install -r requirements.txt
 ```
@@ -66,11 +77,13 @@ pip install -r requirements.txt
 ### 4. Bootstrap CDK (First Time Only)
 
 If this is your first time using CDK in your AWS account/region:
+
 ```bash
 cdk bootstrap aws://ACCOUNT-ID/REGION
 ```
 
 Example:
+
 ```bash
 cdk bootstrap aws://123456789012/us-west-2
 ```
@@ -78,6 +91,7 @@ cdk bootstrap aws://123456789012/us-west-2
 ### 5. Store OpenAI API Key in Secrets Manager
 
 **This is the only manual setup required!**
+
 ```bash
 aws secretsmanager create-secret \
     --name chunkwise/openai-api-key \
@@ -86,14 +100,22 @@ aws secretsmanager create-secret \
 ```
 
 Verify the secret was created:
+
 ```bash
 aws secretsmanager describe-secret \
     --secret-id chunkwise/openai-api-key \
 ```
 
-### 6. (Optional) Adjust configurations and resource sizes if needed in `config.py`
+### 6. Review and Adjust Configuration in `config.py`
 
-If you want to use your own images, update the URIs (from ECR):
+**Resource sizes:**
+
+- Default configuration uses AWS Free Tier eligible resources
+- For production workloads, consider upgrading instance types
+
+**Docker images:**
+If you want to use your own images, update the image URIs (from ECR):
+
 ```python
 DOCKER_IMAGES = {
     "server": "123456789012.dkr.ecr.us-east-1.amazonaws.com/chunkwise-server:latest",
@@ -106,11 +128,13 @@ DOCKER_IMAGES = {
 ## Deployment
 
 ### Option 1: Deploy All Stacks at Once (Recommended)
+
 ```bash
 cdk deploy --all
 ```
 
 This will deploy all four stacks:
+
 1. `ChunkwiseNetworkStack` - VPC with public/private subnets across 2 availability zones, NAT gateways, Internet gateway
 2. `ChunkwiseLoadBalancerStack` - Application Load Balancer, target group, and security group
 3. `ChunkwiseDatabaseStack` - Two RDS PostgreSQL instances (evaluation + production with pgvector), subnet group, security groups, Secrets Manager secrets for credentials
@@ -118,6 +142,7 @@ This will deploy all four stacks:
 5. `ChunkwiseBatchStack` - AWS Batch compute environment, job queue, job definition, IAM roles
 
 ### Option 2: Deploy Stacks Individually
+
 ```bash
 cdk deploy ChunkwiseNetworkStack
 cdk deploy ChunkwiseLoadBalancerStack
@@ -129,6 +154,7 @@ cdk deploy ChunkwiseBatchStack
 ## Accessing the Application
 
 After the load balancer stack deploys, the ALB DNS name will be output:
+
 ```bash
 # Get the load balancer URL
 aws cloudformation describe-stacks \
@@ -149,17 +175,18 @@ The following environment variables are configured automatically by CDK:
 - `DB_HOST` - Evaluation RDS endpoint
 - `DB_NAME` - Evaluation Database name
 - `DB_USER` - Evaluation Database username
--  Evaluation Database credentials stored in Secrets Manager
+- Evaluation Database credentials stored in Secrets Manager
 - `VECTOR_DB_HOST` - Production RDS endpoint
 - `VECTOR_DB_NAME` - Production Database name
 - `VECTOR_DB_PORT` - Production Database port
--  Production Database credentials stored in Secrets Manager
+- Production Database credentials stored in Secrets Manager
 - `CHUNKING_SERVICE_HOST` and `CHUNKING_SERVICE_PORT` - Cloud Map service discovery
 - `EVALUATION_SERVICE_HOST` and `EVALUATION_SERVICE_PORT`- Cloud Map service discovery
 - `S3_BUCKET_NAME` - S3 bucket for storing test documents and LLM-generated queries
 - `OPENAI_API_KEY` - Retrieved from Secrets Manager
 
 Batch Processing Jobs
+
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` - AWS credentials for accessing the user's S3 bucket
 - `DOCUMENT_KEY` - S3 key of document to process (set per job)
 - `BUCKET_NAME` - User's S3 bucket (set per job)
@@ -168,6 +195,7 @@ Batch Processing Jobs
 - `CHUNKER_CONFIG` - Chunking configuration JSON (set per job)
 
 ## Useful CDK Commands
+
 ```bash
 # List all stacks
 cdk ls
@@ -182,14 +210,42 @@ cdk synth ChunkwiseNetworkStack
 cdk deploy --all --dry-run
 ```
 
+## Updating the Deployment
+
+**Recommended for production: Update in place**
+
+```bash
+cdk deploy --all
+```
+
+This updates existing resources without destroying data.
+
+**Complete teardown** (⚠️ rarely needed - see "Destroying the Deployment" section):
+
+- Requires manual cleanup of retained resources
+- Not recommended unless fully decommissioning
+
 ## Destroying the Deployment
 
-**⚠️ Warning: This will delete all resources and data. This action cannot be undone.**
+**⚠️ Warning: Destruction behavior depends on your deployment environment**
+
+### Current Configuration: Production Mode
+
+When you destroy the stack in production mode:
+
+❌ **These resources will be RETAINED** (continue to incur costs):
+
+- RDS PostgreSQL databases (evaluation + production)
+- S3 bucket with documents and queries
+- Database credentials in Secrets Manager
 
 ### Destroy Stacks in the Following Order
+
 ```bash
 # 1. Destroy ECS stack first
 cdk destroy ChunkwiseEcsStack
 
 # 2. Destroy other stacks
 cdk destroy --all
+```
+### Manual

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -10,7 +10,7 @@ os.environ["PYTHON_TYPE_CHECKING_DISABLE"] = "1"
 
 import aws_cdk as cdk
 from stacks.network_stack import NetworkStack
-from stacks.database_stack import DatabaseStack
+from stacks.data_stack import DataStack
 from stacks.ecs_stack import EcsStack
 from stacks.load_balancer_stack import LoadBalancerStack
 from stacks.batch_stack import BatchStack
@@ -21,18 +21,18 @@ app = cdk.App()
 # CDK now expects a json string as context
 options = app.node.try_get_context("options")
 if options:
-    options_json = json.loads(options)
+    OPTIONS_JSON = json.loads(options)
 
-    if not isinstance(options_json, dict):
+    if not isinstance(OPTIONS_JSON, dict):
         raise AttributeError("Must provide an options in JSON format")
 else:
-    options_json = None
+    OPTIONS_JSON = None
 
 
 # Get environment variables or use defaults, for the reason use the one passed in as context
 env = cdk.Environment(
     account=os.getenv("CDK_DEFAULT_ACCOUNT"),
-    region=(options_json and options_json.get("region"))
+    region=(OPTIONS_JSON and OPTIONS_JSON.get("region"))
     or os.getenv("CDK_DEFAULT_REGION", "us-east-1"),
 )
 
@@ -44,13 +44,13 @@ network_stack = NetworkStack(
     description="Chunkwise Network Infrastructure - VPC, Subnets, NAT Gateways",
 )
 
-# Stack 2: Database (RDS PostgreSQL - Evaluation and Production)
-database_stack = DatabaseStack(
+# Stack 2: Data Layer (RDS Instances (Evaluation and Production), S3 Bucket)
+data_stack = DataStack(
     app,
-    "ChunkwiseDatabaseStack",
+    "ChunkwiseDataStack",
     vpc=network_stack.vpc,
     env=env,
-    description="Chunkwise Databases - RDS PostgreSQL Instances",
+    description="Chunkwise Data Layer - RDS PostgreSQL Instances and S3 Bucket",
 )
 
 # Stack 3: ECS Cluster and Services
@@ -58,8 +58,9 @@ ecs_stack = EcsStack(
     app,
     "ChunkwiseEcsStack",
     vpc=network_stack.vpc,
-    database=database_stack.database,
-    vector_database=database_stack.production_database,
+    database=data_stack.database,
+    vector_database=data_stack.production_database,
+    documents_bucket=data_stack.documents_bucket, 
     env=env,
     description="Chunkwise ECS Cluster and Services",
 )
@@ -79,7 +80,7 @@ batch_stack = BatchStack(
     app,
     "ChunkwiseBatchStack",
     vpc=network_stack.vpc,
-    production_database=database_stack.production_database,
+    production_database=data_stack.production_database,
     server_task_role=ecs_stack.task_role,
     env=env,
     description="Chunkwise AWS Batch - Data Ingestion Processing Workflows",

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -2,18 +2,17 @@
 import os
 import warnings
 import json
-
-warnings.filterwarnings(
-    "ignore", message="Typeguard cannot check the", category=UserWarning
-)
-os.environ["PYTHON_TYPE_CHECKING_DISABLE"] = "1"
-
 import aws_cdk as cdk
 from stacks.network_stack import NetworkStack
 from stacks.data_stack import DataStack
 from stacks.ecs_stack import EcsStack
 from stacks.load_balancer_stack import LoadBalancerStack
 from stacks.batch_stack import BatchStack
+
+warnings.filterwarnings(
+    "ignore", message="Typeguard cannot check the", category=UserWarning
+)
+os.environ["PYTHON_TYPE_CHECKING_DISABLE"] = "1"
 
 
 app = cdk.App()
@@ -60,7 +59,7 @@ ecs_stack = EcsStack(
     vpc=network_stack.vpc,
     database=data_stack.database,
     vector_database=data_stack.production_database,
-    documents_bucket=data_stack.documents_bucket, 
+    documents_bucket=data_stack.documents_bucket,
     env=env,
     description="Chunkwise ECS Cluster and Services",
 )

--- a/cdk/config.py
+++ b/cdk/config.py
@@ -3,6 +3,13 @@ Configuration file for Chunkwise CDK deployment
 Update these values according to your environment
 """
 
+from aws_cdk import RemovalPolicy
+
+# Envrionment Configuration
+# Set to "production" for data retention, "development" for auto-cleanup
+ENVIRONMENT = "production"  # Options: "production" | "development"
+
+
 # Docker Image URIs (hardcoded pre-built images)
 # Replace these with your actual ECR image URIs
 DOCKER_IMAGES = {
@@ -48,24 +55,24 @@ RDS_CONFIG = {
     "port": 5432,
     "allocated_storage": 20,  # GB
     "max_allocated_storage": 100,  # GB - for autoscaling
-    "backup_retention_days": 0, # Free tier option
-    "multi_az": False,  # Set to True for production
-    "deletion_protection": False,  # Set to True for production
+    "backup_retention_days": 0,  # Free tier option
+    "multi_az": False,  # Set to True for production HA
+    "deletion_protection": ENVIRONMENT == "production",  # Auto-set based on environment
     "publicly_accessible": False,  # Keep evaluation DB private
 }
 
-# Vector RDS Configuration (Deployment Database)
+# Vector RDS Configuration (Production/Deployment Database)
 VECTOR_RDS_CONFIG = {
     "instance_type": "t4g.micro",  # Same as evaluation DB
     "database_name": "chunkwise_production",
     "port": 5432,
     "allocated_storage": 100,  # GB - larger initial size
     "max_allocated_storage": 500,  # GB - room to grow
-    "backup_retention_days": 0, # Free tier option
+    "backup_retention_days": 0,  # Free tier option
     "multi_az": False,  # Set to True for production HA
-    "deletion_protection": False,  # Set to True for production
+    "deletion_protection": ENVIRONMENT == "production",  # Auto-set based on environment
     "publicly_accessible": True,  # Allow users to export embeddings
-    "allowed_cidrs": [],
+    "allowed_cidrs": [],  # Empty = allow from anywhere. Add specific CIDRs to restrict access
 }
 
 # AWS Batch Configuration
@@ -79,40 +86,54 @@ BATCH_CONFIG = {
 # S3 Configuration
 S3_CONFIG = {"bucket_name_prefix": "chunkwise"}  # Will append account ID
 
-# Environment Variables
-# These are set dynamically by the stacks and injected into ECS task definitions
-# Listed for documentation purposes
-ENVIRONMENT_VARIABLES = {
-    # Evaluation Database (set by DatabaseStack)
-    # "DB_HOST": evaluation_db.instance_endpoint.hostname
-    # "DB_NAME": "chunkwise"
-    # "DB_PORT": "5432"
-    # "DB_USER": from Secrets Manager
-    # "DB_PASSWORD": from Secrets Manager
-    
-    # Production Vector Database (set by DatabaseStack)
-    # "VECTOR_DB_HOST": production_db.instance_endpoint.hostname
-    # "VECTOR_DB_NAME": "chunkwise_production"
-    # "VECTOR_DB_PORT": "5432"
-    
-    # S3 Bucket (set by EcsStack)
-    # "S3_BUCKET_NAME": documents_bucket.bucket_name
-    
-    # Service Discovery (set by EcsStack)
-    # "CHUNKING_SERVICE_HOST": "chunking.chunkwise"
-    # "CHUNKING_SERVICE_PORT": "80"
-    # "EVALUATION_SERVICE_HOST": "evaluation.chunkwise"
-    # "EVALUATION_SERVICE_PORT": "80"
-    
-    # Embedding Configuration
-    # "EMBEDDING_DIM": "1536"
-    
-    # Secrets from Secrets Manager
-    # "OPENAI_API_KEY": from chunkwise/openai-api-key
-}
-
 # Cloud Map Configuration
 CLOUD_MAP_CONFIG = {
     "namespace_name": "chunkwise",
     "services": {"chunking": "chunking", "evaluation": "evaluation"},
 }
+
+# Environment Variables
+# These are set dynamically by the stacks and injected into ECS task definitions
+# Listed for documentation purposes only
+
+"""
+ENVIRONMENT_VARIABLES = {
+    # Evaluation Database (set by DatabaseStack)
+    "DB_HOST": evaluation_db.instance_endpoint.hostname
+    "DB_NAME": "chunkwise"
+    "DB_PORT": "5432"
+    "DB_USER": from Secrets Manager
+    "DB_PASSWORD": from Secrets Manager
+
+    # Production Vector Database (set by DatabaseStack)
+    "VECTOR_DB_HOST": production_db.instance_endpoint.hostname
+    "VECTOR_DB_NAME": "chunkwise_production"
+    "VECTOR_DB_PORT": "5432"
+
+    # S3 Bucket (set by EcsStack)
+    "S3_BUCKET_NAME": documents_bucket.bucket_name
+
+    # Service Discovery (set by EcsStack)
+    "CHUNKING_SERVICE_HOST": "chunking.chunkwise"
+    "CHUNKING_SERVICE_PORT": "80"
+    "EVALUATION_SERVICE_HOST": "evaluation.chunkwise"
+    "EVALUATION_SERVICE_PORT": "80"
+
+    # Embedding Configuration
+    "EMBEDDING_DIM": "1536"
+    
+    # Secrets from Secrets Manager
+    "OPENAI_API_KEY": from chunkwise/openai-api-key
+}
+"""
+
+
+# Helper Functions
+def is_production() -> bool:
+    """Check if running in production mode"""
+    return ENVIRONMENT == "production"
+
+
+def get_removal_policy():
+    """Get CDK removal policy based on environment"""
+    return RemovalPolicy.RETAIN if is_production() else RemovalPolicy.DESTROY

--- a/cdk/stacks/__init__.py
+++ b/cdk/stacks/__init__.py
@@ -3,8 +3,8 @@ Chunkwise CDK Stacks Package
 """
 
 from .network_stack import NetworkStack
-from .database_stack import DatabaseStack
+from .data_stack import DataStack
 from .ecs_stack import EcsStack
 from .load_balancer_stack import LoadBalancerStack
 
-__all__ = ["NetworkStack", "DatabaseStack", "EcsStack", "LoadBalancerStack"]
+__all__ = ["NetworkStack", "DataStack", "EcsStack", "LoadBalancerStack"]

--- a/cdk/stacks/data_stack.py
+++ b/cdk/stacks/data_stack.py
@@ -21,7 +21,7 @@ class DataStack(Stack):
     - 2 RDS Security Groups (one for each database)
     - 2 RDS PostgreSQL Instances (evaluation and production)
     - 2 Secrets (for database credentials)
-    - 1 S3 Bucket (for data storage)
+    - 1 S3 Bucket (for document storage)
     """
 
     def __init__(

--- a/cdk/stacks/data_stack.py
+++ b/cdk/stacks/data_stack.py
@@ -29,6 +29,10 @@ class DataStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # Read context flag for allowing destructive data deletion
+        allow_rds_delete = self.node.try_get_context("allow_rds_delete")
+        self._allow_rds_delete = str(allow_rds_delete).lower() == "true"
+
         # Create S3 bucket for document storage
         self.documents_bucket = s3.Bucket(
             self,
@@ -37,8 +41,14 @@ class DataStack(Stack):
             encryption=s3.BucketEncryption.S3_MANAGED,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             versioned=False,
-            removal_policy=config.get_removal_policy(),      # RETAIN in prod, DESTROY in dev
-            auto_delete_objects=not config.is_production(),  # Only auto-delete in dev
+            removal_policy=(
+                RemovalPolicy.DESTROY
+                if self._allow_rds_delete
+                else config.get_removal_policy()
+            ),
+            auto_delete_objects=(
+                True if self._allow_rds_delete else not config.is_production()
+            ),
         )
 
         # Create Evaluation Database (for experimentation workflows)
@@ -66,7 +76,6 @@ class DataStack(Stack):
             username="postgres",
             secret_name="chunkwise/db-credentials",
         )
-        self.db_credentials.apply_removal_policy(config.get_removal_policy())
 
         # Create RDS PostgreSQL instance for evaluation
         self.database = rds.DatabaseInstance(
@@ -100,9 +109,17 @@ class DataStack(Stack):
             # Public accessibility
             publicly_accessible=config.RDS_CONFIG["publicly_accessible"],
             # Deletion protection
-            deletion_protection=config.RDS_CONFIG["deletion_protection"],
-            # For development - allow deletion
-            removal_policy=config.get_removal_policy(),
+            deletion_protection=(
+                False
+                if self._allow_rds_delete
+                else config.RDS_CONFIG["deletion_protection"]
+            ),
+            # Allow deletion in development or when running `destroy-data` in protection
+            removal_policy=(
+                RemovalPolicy.DESTROY
+                if self._allow_rds_delete
+                else config.get_removal_policy()
+            ),
             # CloudWatch monitoring
             cloudwatch_logs_exports=["postgresql"],
             enable_performance_insights=True,
@@ -154,7 +171,6 @@ class DataStack(Stack):
             username="postgres",
             secret_name="chunkwise/production-db-credentials",
         )
-        self.production_db_credentials.apply_removal_policy(config.get_removal_policy())
 
         # Create RDS PostgreSQL instance for production
         self.production_database = rds.DatabaseInstance(
@@ -188,9 +204,17 @@ class DataStack(Stack):
             # Public accessibility - ENABLED for user export
             publicly_accessible=config.VECTOR_RDS_CONFIG["publicly_accessible"],
             # Deletion protection
-            deletion_protection=config.VECTOR_RDS_CONFIG["deletion_protection"],
-            # For development - allow deletion
-            removal_policy=config.get_removal_policy(),
+            deletion_protection=(
+                False
+                if self._allow_rds_delete
+                else config.VECTOR_RDS_CONFIG["deletion_protection"]
+            ),
+            # Allow deletion in development or when running `destroy-data` in protection
+            removal_policy=(
+                RemovalPolicy.DESTROY
+                if self._allow_rds_delete
+                else config.get_removal_policy()
+            ),
             # CloudWatch monitoring
             cloudwatch_logs_exports=["postgresql"],
             enable_performance_insights=True,

--- a/cdk/stacks/data_stack.py
+++ b/cdk/stacks/data_stack.py
@@ -3,6 +3,7 @@ from aws_cdk import (
     aws_ec2 as ec2,
     aws_rds as rds,
     aws_secretsmanager as secretsmanager,
+    aws_s3 as s3,
     RemovalPolicy,
     Duration,
     CfnOutput,
@@ -11,21 +12,34 @@ from constructs import Construct
 import config
 
 
-class DatabaseStack(Stack):
+class DataStack(Stack):
     """
-    Database Stack - Creates RDS PostgreSQL instance
+    Data Stack - Creates RDS instances for evaluation and production databases and S3 bucket
 
     Resources created:
     - 1 RDS Subnet Group (shared)
     - 2 RDS Security Groups (one for each database)
     - 2 RDS PostgreSQL Instances (evaluation and production)
     - 2 Secrets (for database credentials)
+    - 1 S3 Bucket (for data storage)
     """
 
     def __init__(
         self, scope: Construct, construct_id: str, vpc: ec2.Vpc, **kwargs
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        # Create S3 bucket for document storage
+        self.documents_bucket = s3.Bucket(
+            self,
+            "ChunkwiseDocumentsBucket",
+            bucket_name=f"{config.S3_CONFIG['bucket_name_prefix']}-{self.account}",
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            versioned=False,
+            removal_policy=config.get_removal_policy(),      # RETAIN in prod, DESTROY in dev
+            auto_delete_objects=not config.is_production(),  # Only auto-delete in dev
+        )
 
         # Create Evaluation Database (for experimentation workflows)
         self._create_evaluation_database(vpc)

--- a/cdk/stacks/data_stack.py
+++ b/cdk/stacks/data_stack.py
@@ -114,7 +114,7 @@ class DataStack(Stack):
                 if self._allow_rds_delete
                 else config.RDS_CONFIG["deletion_protection"]
             ),
-            # Allow deletion in development or when running `destroy-data` in protection
+            # Allow deletion in development or when running `destroy-data` in production
             removal_policy=(
                 RemovalPolicy.DESTROY
                 if self._allow_rds_delete
@@ -209,7 +209,7 @@ class DataStack(Stack):
                 if self._allow_rds_delete
                 else config.VECTOR_RDS_CONFIG["deletion_protection"]
             ),
-            # Allow deletion in development or when running `destroy-data` in protection
+            # Allow deletion in development or when running `destroy-data` in production
             removal_policy=(
                 RemovalPolicy.DESTROY
                 if self._allow_rds_delete

--- a/cdk/stacks/database_stack.py
+++ b/cdk/stacks/database_stack.py
@@ -52,6 +52,7 @@ class DatabaseStack(Stack):
             username="postgres",
             secret_name="chunkwise/db-credentials",
         )
+        self.db_credentials.apply_removal_policy(config.get_removal_policy())
 
         # Create RDS PostgreSQL instance for evaluation
         self.database = rds.DatabaseInstance(
@@ -139,6 +140,7 @@ class DatabaseStack(Stack):
             username="postgres",
             secret_name="chunkwise/production-db-credentials",
         )
+        self.production_db_credentials.apply_removal_policy(config.get_removal_policy())
 
         # Create RDS PostgreSQL instance for production
         self.production_database = rds.DatabaseInstance(

--- a/cdk/stacks/database_stack.py
+++ b/cdk/stacks/database_stack.py
@@ -87,7 +87,7 @@ class DatabaseStack(Stack):
             # Deletion protection
             deletion_protection=config.RDS_CONFIG["deletion_protection"],
             # For development - allow deletion
-            removal_policy=RemovalPolicy.DESTROY,  # Change to RETAIN for production
+            removal_policy=config.get_removal_policy(),
             # CloudWatch monitoring
             cloudwatch_logs_exports=["postgresql"],
             enable_performance_insights=True,
@@ -174,7 +174,7 @@ class DatabaseStack(Stack):
             # Deletion protection
             deletion_protection=config.VECTOR_RDS_CONFIG["deletion_protection"],
             # For development - allow deletion
-            removal_policy=RemovalPolicy.DESTROY,  # Change to RETAIN for production
+            removal_policy=config.get_removal_policy(),
             # CloudWatch monitoring
             cloudwatch_logs_exports=["postgresql"],
             enable_performance_insights=True,

--- a/cdk/stacks/ecs_stack.py
+++ b/cdk/stacks/ecs_stack.py
@@ -26,7 +26,6 @@ class EcsStack(Stack):
     - 1 Cloud Map Private DNS Namespace
     - 2 Cloud Map Service Discovery Services (chunking, evaluation)
     - 3 CloudWatch Log Groups
-    - 1 S3 Bucket
     - 2 IAM Roles (Task Execution Role, Task Role)
     - Security Groups
     """
@@ -38,6 +37,7 @@ class EcsStack(Stack):
         vpc: ec2.Vpc,
         database: rds.DatabaseInstance,
         vector_database: rds.DatabaseInstance,
+        documents_bucket: s3.IBucket,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -45,18 +45,7 @@ class EcsStack(Stack):
         self.vpc = vpc
         self.database = database
         self.vector_database = vector_database
-
-        # Create S3 bucket for document storage
-        self.documents_bucket = s3.Bucket(
-            self,
-            "ChunkwiseDocumentsBucket",
-            bucket_name=f"{config.S3_CONFIG['bucket_name_prefix']}-{self.account}",
-            encryption=s3.BucketEncryption.S3_MANAGED,
-            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
-            versioned=False,
-            removal_policy=config.get_removal_policy(),
-            auto_delete_objects=not config.is_production(),  # Only auto-delete in dev
-        )
+        self.documents_bucket = documents_bucket
 
         # Create security group for ECS tasks
         self.ecs_security_group = ec2.SecurityGroup(

--- a/cdk/stacks/ecs_stack.py
+++ b/cdk/stacks/ecs_stack.py
@@ -54,8 +54,8 @@ class EcsStack(Stack):
             encryption=s3.BucketEncryption.S3_MANAGED,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             versioned=False,
-            removal_policy=RemovalPolicy.DESTROY,  # Change to RETAIN for production
-            auto_delete_objects=True,  # Only for development
+            removal_policy=config.get_removal_policy(),
+            auto_delete_objects=not config.is_production(),  # Only auto-delete in dev
         )
 
         # Create security group for ECS tasks

--- a/cli/README.md
+++ b/cli/README.md
@@ -95,9 +95,9 @@ You will be required to type `DELETE DATA` to confirm.
 
 ## Fully removing production resources manually
 
-If you want to completely remove all retained production resources without using the CLI, here are the commands:
+If you want to completely remove all retained production resources without using the CLI, use the following commands and make sure to pass `--region` if not using the default one:
 
-Delete the OpenAI API key (optionally add `region` if not using the default one):
+Delete the OpenAI API key:
 
 ```bash
 aws secretsmanager delete-secret \
@@ -106,7 +106,7 @@ aws secretsmanager delete-secret \
  --region <YOUR_REGION>
 ```
 
-Delete database credentials (optionally add `region` if not using the default one):
+Delete database credentials:
 
 ```bash
 aws secretsmanager delete-secret \
@@ -123,13 +123,13 @@ aws secretsmanager delete-secret \
 Delete the S3 bucket:
 
 ```bash
-aws s3 rm s3://chunkwise-<ACCOUNT_ID> --recursive
-aws s3api delete-bucket --bucket chunkwise-<ACCOUNT_ID>
+aws s3 rm s3://chunkwise-<ACCOUNT_ID> --recursive --region <YOUR_REGION>
+aws s3api delete-bucket --bucket chunkwise-<ACCOUNT_ID> --region <YOUR_REGION>
 ```
 
 Delete remaining stacks:
 
 ```bash
-cdk destroy ChunkwiseDataStack
-cdk destroy ChunkwiseNetworkStack
+cdk destroy ChunkwiseDataStack --force --region <YOUR_REGION>
+cdk destroy ChunkwiseNetworkStack --force --region <YOUR_REGION>
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -130,6 +130,6 @@ aws s3api delete-bucket --bucket chunkwise-<ACCOUNT_ID>
 Delete remaining stacks:
 
 ```bash
-cdk destroy ChunkwiseNetworkStack
 cdk destroy ChunkwiseDataStack
+cdk destroy ChunkwiseNetworkStack
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -130,6 +130,6 @@ aws s3api delete-bucket --bucket chunkwise-<ACCOUNT_ID> --region <YOUR_REGION>
 Delete remaining stacks:
 
 ```bash
-cdk destroy ChunkwiseDataStack --force --region <YOUR_REGION>
-cdk destroy ChunkwiseNetworkStack --force --region <YOUR_REGION>
+cdk destroy ChunkwiseDataStack --force -c options='{"region":"<YOUR_REGION>"}'
+cdk destroy ChunkwiseNetworkStack --force -c options='{"region":"<YOUR_REGION>"}'
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,12 +17,6 @@ Initiates a user interface that gathers the necessary information
 to deploy the stacks. It then installs necessary dependencies,
 creates a secret, and bootstraps and deploys the AWS stacks.
 
-`typer cli.py run destroy (--region=<NON_DEFAULT_REGION_HERE>)`
-
-Forcefully deletes all of the AWS stacks created by deploy. Note
-that this doesn't destroy the S3 bucket or RDS instances. Also,
-if you used a non-default region make sure to specify that here.
-
 `typer cli.py run client (--region=<NON_DEFAULT_REGION_HERE>)`
 
 Runs both the `client-build` and `client-start` commands.
@@ -38,6 +32,104 @@ off.
 
 Runs a built client using Vite. To stop the server use Ctrl^C.
 
-# If you would like to destroy the created secret manually use this command:
+`typer cli.py run destroy (--region=<NON_DEFAULT_REGION_HERE>)`
 
-`aws secretsmanager delete-secret --secret-id chunkwise/openai-api-key --force-delete-without-recovery --region <YOUR_REGION_HERE>`
+Destroys AWS resources deployed by the CLI.
+Destruction behavior depends on the environment mode (set in `cdk/config.py):
+
+### Development mode
+
+Completely removes all stacks and deletes all secrets:
+
+- All CloudFormation stacks
+- Secrets Manager entries (including database credentials and OpenAI API key)
+- The S3 bucket
+- Both RDS instances
+
+This is a complete teardown.
+
+### Production mode
+
+Only destroys the application-layer stacks:
+
+- ChunkwiseEcsStack
+- ChunkwiseLoadBalancerStack
+- ChunkwiseBatchStack
+
+Retains:
+
+- ChunkwiseNetworkStack
+- ChunkwiseDataStack (including 2 RDS instances and S3 bucket)
+- All database credentials and OpenAI API key in Secrets Manager
+
+This prevents accidental loss of persistent production data.
+
+To fully decommission and remove retained production data, see below.
+
+`typer cli.py run destroy-data (--region=<REGION>)`
+🔥 Permanently deletes all remaining resources after the regular `destroy`, including the data layer and the network stack (PRODUCTION ONLY)
+
+This command irreversibly deletes:
+
+- ChunkwiseDataStack (including 2 RDS instances and the S3 bucket)
+- Database credentials and OpenAI API key secrets
+- Any retained data in ChunkwiseDataStack
+- ChunkwiseNetworkStack
+
+What it does not delete:
+
+- ChunkwiseEcsStack
+- ChunkwiseLoadBalancerStack
+- ChunkwiseBatchStack
+
+How it works:
+`destroy-data` internally:
+
+- Re-deploys ChunkwiseDataStack with `allow_rds_delete=true`
+- Disables deletion protection on both RDS instances
+- Destroys ChunkwiseDataStack
+- Deletes chunkwise/db-credentials and chunkwise/production-db-credentials
+- Destroys ChunkwiseNetworkStack
+
+You will be required to type `DELETE DATA` to confirm.
+
+## Fully removing production resources manually
+
+If you want to completely remove all retained production resources without using the CLI, here are the commands:
+
+Delete the OpenAI API key (optionally add `region` if not using the default one):
+
+```bash
+aws secretsmanager delete-secret \
+ --secret-id chunkwise/openai-api-key \
+ --force-delete-without-recovery \
+ --region <YOUR_REGION>
+```
+
+Delete database credentials (optionally add `region` if not using the default one):
+
+```bash
+aws secretsmanager delete-secret \
+ --secret-id chunkwise/db-credentials \
+ --force-delete-without-recovery \
+ --region <YOUR_REGION>
+
+ aws secretsmanager delete-secret \
+ --secret-id chunkwise/production-db-credentials \
+ --force-delete-without-recovery \
+ --region <YOUR_REGION>
+```
+
+Delete the S3 bucket:
+
+```bash
+aws s3 rm s3://chunkwise-<ACCOUNT_ID> --recursive
+aws s3api delete-bucket --bucket chunkwise-<ACCOUNT_ID>
+```
+
+Delete remaining stacks:
+
+```bash
+cdk destroy ChunkwiseNetworkStack
+cdk destroy ChunkwiseDataStack
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,7 @@ Initiates a user interface that gathers the necessary information
 to deploy the stacks. It then installs necessary dependencies,
 creates a secret, and bootstraps and deploys the AWS stacks.
 
-`typer cli.py run client (--region=<NON_DEFAULT_REGION_HERE>)`
+`typer cli.py run client-run (--region=<NON_DEFAULT_REGION_HERE>)`
 
 Runs both the `client-build` and `client-start` commands.
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,18 +1,16 @@
+import re
+from pathlib import Path
+import subprocess
+import importlib.util
 import json
 import boto3
 from botocore.exceptions import ClientError
 import typer
 from typing_extensions import Annotated
-from rich import print
-from rich.pretty import pprint
-from rich.prompt import Prompt, Confirm, InvalidResponse
+from rich.prompt import Prompt, Confirm
 from rich.live import Live
 from rich.console import Console
 from rich.table import Table
-import re
-from pathlib import Path
-import subprocess
-import importlib.util
 
 
 DEPLOY_RE = re.compile(
@@ -37,21 +35,23 @@ env = cdk_config.ENVIRONMENT.lower()  # "production" or "development"
 
 
 def validate_key(key):
+    """Simple validation for OpenAI API key format."""
     if not isinstance(key, str) or len(key) == 0 or not key.startswith("sk-"):
         return False
     return True
 
 
 def display_logo():
-    with open("logo.txt") as logo_file:
+    """Displays the Chunkwise logo in the terminal."""
+    with open("logo.txt", encoding="utf-8") as logo_file:
         logo_text = logo_file.read()
 
-    print(f"[#00BCF7]{logo_text}")
+    console.print(f"[#00BCF7]{logo_text}")
 
-    with open("chunkwise_monospace.txt") as name_file:
+    with open("chunkwise_monospace.txt", encoding="utf-8") as name_file:
         text = name_file.read()
 
-    print(f"[white]{text}")
+    console.print(f"[white]{text}")
 
 
 def ensure_cdk_dependencies():
@@ -63,10 +63,10 @@ def ensure_cdk_dependencies():
     req_file = CDK_DIR / "requirements.txt"
 
     if req_file.exists():
-        print(f"[yellow]📦 Ensuring CDK dependencies...")
+        console.print("[yellow]📦 Ensuring CDK dependencies...")
         cmd = ["pip", "install", "-r", "requirements.txt"]
     else:
-        print(f"[red]⚠️ No dependency file found in CDK directory.")
+        console.print("[red]⚠️ No dependency file found in CDK directory.")
         return
 
     # Install inside the CDK directory
@@ -78,17 +78,13 @@ def ensure_cdk_dependencies():
         text=True,
     )
 
-    # Print the output to the console
-    # for line in proc.stdout:
-    #     typer.echo(line.rstrip())
-
     proc.wait()
 
     if proc.returncode != 0:
-        print(f"[red]❌ CDK dependency installation failed.")
+        console.print("[red]❌ CDK dependency installation failed.")
         raise typer.Exit(code=1)
 
-    print(f"[green]✅ CDK dependencies ready!")
+    console.print("[green]✅ CDK dependencies ready!")
 
 
 def ensure_npm_dependencies():
@@ -101,14 +97,14 @@ def ensure_npm_dependencies():
     package_json = CLIENT_DIR / "package.json"
 
     if not package_json.exists():
-        print(f"[yellow]⚠️ No package.json found in client directory.")
+        console.print("[yellow]⚠️ No package.json found in client directory.")
         return
 
     if node_modules.exists():
-        print(f"[green]📦 Client NPM dependencies already installed.")
+        console.print("[green]📦 Client NPM dependencies already installed.")
         return
 
-    print(f"[yellow]📦 Installing NPM dependencies for client...")
+    console.print("[yellow]📦 Installing NPM dependencies for client...")
 
     try:
         proc = subprocess.Popen(
@@ -123,14 +119,14 @@ def ensure_npm_dependencies():
         proc.wait()
 
         if proc.returncode != 0:
-            print(f"[red]❌ NPM install failed.")
+            console.print("[red]❌ NPM install failed.")
             raise typer.Exit(code=1)
 
-    except FileNotFoundError:
-        print(f"[red]❌ NPM is not installed or not in PATH.")
-        raise typer.Exit(code=1)
+    except FileNotFoundError as exc:
+        console.print("[red]❌ NPM is not installed or not in PATH.")
+        raise typer.Exit(code=1) from exc
 
-    print(f"[green]✅ Client NPM dependencies ready!")
+    console.print("[green]✅ Client NPM dependencies ready!")
 
 
 def run_cdk_command(*args):
@@ -139,7 +135,7 @@ def run_cdk_command(*args):
     Streams output live and preserves exit codes.
     """
 
-    print(f"[yellow]👉 Running: cdk {' '.join(args)} (in {CDK_DIR})")
+    console.print(f"[yellow]👉 Running: cdk {' '.join(args)} (in {CDK_DIR})")
 
     proc = subprocess.Popen(
         ["cdk"] + list(args),
@@ -169,10 +165,6 @@ def run_cdk_command(*args):
 
                 table.add_row(index, status, resource)
                 live.update(table)
-            else:
-                # For non-event lines, just print normally
-                # console.print(line)
-                pass
 
     proc.wait()
     if proc.returncode != 0:
@@ -184,7 +176,7 @@ def run_client_command(*args):
     Runs a npm command from the client directory.
     """
 
-    print(f"[yellow]👉 Running: npm run {' '.join(args)} (in {CLIENT_DIR})")
+    console.print(f"[yellow]👉 Running: npm run {' '.join(args)} (in {CLIENT_DIR})")
 
     try:
         proc = subprocess.Popen(
@@ -205,9 +197,9 @@ def run_client_command(*args):
         if proc.returncode != 0:
             raise typer.Exit(code=proc.returncode)
 
-    except FileNotFoundError:
-        print(f"[red]❌ Error: Packages are not installed or not in PATH.")
-        raise typer.Exit(code=1)
+    except FileNotFoundError as exc:
+        console.print("[red]❌ Error: Packages are not installed or not in PATH.")
+        raise typer.Exit(code=1) from exc
 
 
 def create_secret(secret_name, secret_value, region=None):
@@ -226,16 +218,17 @@ def create_secret(secret_name, secret_value, region=None):
 
         client.create_secret(Name=secret_name, SecretString=secret_value)
 
-        print(f'[green]✅ AWS Secret "{secret_name}" created!')
+        console.print(f'[green]✅ AWS Secret "{secret_name}" created!')
 
     except ClientError as e:
         if e.response["Error"]["Code"] == "ResourceExistsException":
-            print(f'[green]✅ Secret "{secret_name}" already exists.')
+            console.print(f'[green]✅ Secret "{secret_name}" already exists.')
         else:
             raise
 
 
 def delete_secret(secret_name, region):
+    """Deletes a secret from AWS Secrets Manager."""
     if not secret_name:
         raise ValueError("secret name must be provided")
 
@@ -246,7 +239,7 @@ def delete_secret(secret_name, region):
 
     client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
 
-    print(f'[green]✅ AWS Secret "{secret_name}" deleted!')
+    console.print(f'[green]✅ AWS Secret "{secret_name}" deleted!')
 
 
 def write_env_file(client_dir: str, values: dict):
@@ -296,8 +289,6 @@ def get_alb_dns(load_balancer_name, region=None):
     else:
         client = boto3.client("elbv2")
 
-    # print(client.describe_load_balancers())
-
     response = client.describe_load_balancers(
         Names=[
             load_balancer_name,
@@ -306,7 +297,7 @@ def get_alb_dns(load_balancer_name, region=None):
 
     alb_dns = response["LoadBalancers"][0]["DNSName"]
 
-    print(f"[green]✅ Retrieved load balancer DNS.")
+    console.print("[green]✅ Retrieved load balancer DNS.")
 
     return alb_dns
 
@@ -327,13 +318,13 @@ def deploy():
     openai_api_key = ""
     while not validate_key(openai_api_key):
         openai_api_key = Prompt.ask(
-            f"[#00BCF7]OpenAI API Key", password=True
+            "[#00BCF7]OpenAI API Key", password=True
         )  # Could make password True to hide while typing
         openai_api_key = openai_api_key.strip()
         print()
 
     region = Prompt.ask(
-        f"[#00BCF7]What region would you like to deploy Chunkwise in?",
+        "[#00BCF7]What region would you like to deploy Chunkwise in?",
         # Default available regions
         choices=[
             "ap-northeast-1",
@@ -361,38 +352,38 @@ def deploy():
     )
     print()
 
-    region = str.lower(region)
+    region = region.lower()
 
     if env == "production":
         # Add production mode warning
-        print(
-            f"[yellow]⚠️  Production mode: Databases and S3 will be RETAINED on stack deletion."
+        console.print(
+            "[yellow]⚠️  Production mode: Databases and S3 will be RETAINED on stack deletion."
         )
-        print(
-            f"[yellow]   To use development mode, set ENVIRONMENT='development' in cdk/config.py."
+        console.print(
+            "[yellow]   To use development mode, set ENVIRONMENT='development' in cdk/config.py."
         )
     else:
-        print(
+        console.print(
             "[yellow]⚠️  Development mode: Stacks and secrets will be fully destroyed on teardown."
         )
     print()
 
-    confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
+    confirm = Confirm.ask("[#00BCF7]Are you sure?")
     print()
 
     if not confirm:
-        print(f"[red]❌ Stack deployment cancelled.")
+        console.print("[red]❌ Stack deployment cancelled.")
         return
 
-    options = {
-        "region": "" if region == "my default" else region,
-    }
+    region = None if region == "my default" else region
+
+    options = {"region": region}
     options_json = json.dumps(options)
     account_id = boto3.client("sts").get_caller_identity().get("Account")
 
     ensure_cdk_dependencies()
 
-    if region != "my default":
+    if region is not None:
         create_secret("chunkwise/openai-api-key", openai_api_key, region)
         run_cdk_command("bootstrap", f"aws://{account_id}/{region}")
     else:
@@ -408,7 +399,7 @@ def deploy():
         f"options={options_json}",
     )
 
-    print(f"[green]✅ Stacks successfullly deployed.")
+    console.print("[green]✅ Stacks successfullly deployed.")
 
 
 @app.command()
@@ -423,27 +414,29 @@ def destroy(
 
     if env == "production":
         # Add production mode warning
-        print(f"[yellow]⚠️  Production mode: The following resources will be RETAINED:")
-        print(f"[yellow]   • Network stack (VPC, Subnets, NAT Gateways, etc.)")
-        print(
-            f"[yellow]   • Data stack (2 RDS instances, S3 bucket, DB subnet group, security groups, etc.)"
+        console.print(
+            "[yellow]⚠️  Production mode: The following resources will be RETAINED:"
         )
-        print(
-            f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager"
+        console.print("[yellow]   • Network stack (VPC, Subnets, NAT Gateways, etc.)")
+        console.print(
+            "[yellow]   • Data stack (2 RDS instances, S3 bucket, DB subnet group, security groups, etc.)"
+        )
+        console.print(
+            "[yellow]   • Database credentials and OpenAI API key in Secrets Manager"
         )
         print()
-        print(
-            f"[yellow]   These resources will continue to incur costs. "
+        console.print(
+            "[yellow]   These resources will continue to incur costs. "
             "To fully clean up, see instructions in cdk/README.md."
         )
         print()
     else:
-        print(
-            f"[yellow]⚠️  Development mode: All resources will be destroyed, including secrets."
+        console.print(
+            "[yellow]⚠️  Development mode: All resources will be destroyed, including secrets."
         )
         print()
 
-    confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
+    confirm = Confirm.ask("[#00BCF7]Are you sure?")
     print()
 
     options = {
@@ -452,7 +445,7 @@ def destroy(
     options_json = json.dumps(options)
 
     if not confirm:
-        print(f"[red]❌ Stack destruction cancelled.")
+        console.print("[red]❌ Stack destruction cancelled.")
         return
 
     ensure_cdk_dependencies()
@@ -473,8 +466,8 @@ def destroy(
             "destroy", "ChunkwiseBatchStack", "--force", "-c", f"options={options_json}"
         )
 
-        print(
-            f"[green]✅ ECS, Load Balancer, and Batch stacks destroyed. "
+        console.print(
+            "[green]✅ ECS, Load Balancer, and Batch stacks destroyed. "
             "Network and Database stacks and secrets retained."
         )
     else:
@@ -491,7 +484,123 @@ def destroy(
         )
         delete_secret("chunkwise/openai-api-key", region)
 
-        print(f"[green]✅ All stacks destroyed and secrets deleted.")
+        console.print("[green]✅ All stacks destroyed and secrets deleted.")
+
+
+@app.command()
+def destroy_data(
+    region: Annotated[
+        str, typer.Option(help="AWS region of the deployed stacks")
+    ] = None,
+):
+    """
+    Permanently destroy all data-layer resources and the supporting network stack in PRODUCTION.
+
+    This will:
+    - Disable deletion protection on the evaluation and production RDS instances
+    - Destroy the ChunkwiseDataStack (including 2 RDS instances + S3 bucket)
+    - Destroy the ChunkwiseNetworkStack (VPC, subnets, NAT, etc.)
+    - Delete database credentials and OpenAI API key from Secrets Manager
+
+    WARNING: This is irreversible. Use only when you truly want to wipe data.
+    """
+
+    if env != "production":
+        console.print("[yellow]⚠️  You're in development mode.")
+        console.print(
+            "[yellow]   Use the regular 'destroy' command instead - it will destroy everything."
+        )
+        return
+
+    console.print("[red]🔥 FULL DATA RESOURCES TEARDOWN (PRODUCTION) 🔥[/red]")
+    console.print("[yellow]This will attempt to permanently delete:[/yellow]")
+    print("  • Evaluation RDS instance")
+    print("  • Production RDS instance")
+    print("  • S3 documents bucket")
+    print("  • Database credentials and OpenAI API key in Secrets Manager")
+    print("  • Network stack (VPC, subnets, NAT gateways, etc.)")
+    print()
+    console.print(
+        "[yellow]This action is IRREVERSIBLE and may result in permanent data loss.[/yellow]"
+    )
+    print()
+
+    # Extra safety: require exact phrase
+    confirm_phrase = Prompt.ask(
+        "[#00BCF7]Type 'DELETE DATA' to confirm (or anything else to cancel)"
+    ).strip()
+
+    if confirm_phrase != "DELETE DATA":
+        console.print("[red]❌ Data destruction cancelled.")
+        return
+
+    region = None if region == "my default" else region
+
+    options = {"region": region}
+    options_json = json.dumps(options)
+
+    ensure_cdk_dependencies()
+
+    # 1) First: deploy DataStack with allow_rds_delete=true to turn off deletion protection
+    console.print(
+        "[yellow]👉 Step 1/4: Updating ChunkwiseDataStack to disable RDS deletion protection..."
+    )
+    run_cdk_command(
+        "deploy",
+        "ChunkwiseDataStack",
+        "--require-approval",
+        "never",
+        "-c",
+        f"options={options_json}",
+        "-c",
+        "allow_rds_delete=true",
+    )
+
+    # 2) Then: destroy DataStack with the same context flag
+    console.print("[yellow]👉 Step 2/4: Destroying ChunkwiseDataStack (RDS + S3)...")
+    run_cdk_command(
+        "destroy",
+        "ChunkwiseDataStack",
+        "--force",
+        "-c",
+        f"options={options_json}",
+        "-c",
+        "allow_rds_delete=true",
+    )
+
+    # 3) Destroy the Network stack (now that nothing depends on it anymore)
+    console.print(
+        "[yellow]👉 Step 3/4: Destroying ChunkwiseNetworkStack (VPC, subnets, NAT)..."
+    )
+    run_cdk_command(
+        "destroy",
+        "ChunkwiseNetworkStack",
+        "--force",
+        "-c",
+        f"options={options_json}",
+    )
+
+    # 4) Delete all remaining secrets (RDS credentials + OpenAI API key)
+    console.print("[yellow]👉 Step 4/4: Deleting Secrets Manager entries...")
+
+    secret_names = [
+        "chunkwise/openai-api-key",
+        "chunkwise/db-credentials",
+        "chunkwise/production-db-credentials",
+    ]
+
+    for name in secret_names:
+        try:
+            delete_secret(name, region)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                console.print(f"[yellow]ℹ️ Secret '{name}' already deleted.")
+            else:
+                raise
+
+    console.print(
+        "[green]✅ All data, secrets, and network resources have been removed."
+    )
 
 
 @app.command()
@@ -511,7 +620,7 @@ def client_build(
     write_env_file("../client", {"ALB_URI": alb_dns})
     ensure_npm_dependencies()
     run_client_command("build")
-    print(f"[green]✅ Client built!")
+    console.print("[green]✅ Client built!")
 
 
 @app.command()
@@ -524,7 +633,7 @@ def client_start():
 
 
 @app.command()
-def client(
+def client_cmd(
     region: Annotated[
         str, typer.Option(help="AWS region of the deployed stacks")
     ] = None,

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -120,10 +120,6 @@ def ensure_npm_dependencies():
             bufsize=1,
         )
 
-        # Log output to the console
-        # for line in proc.stdout:
-        #     typer.echo(line.rstrip())
-
         proc.wait()
 
         if proc.returncode != 0:
@@ -373,7 +369,7 @@ def deploy():
             f"[yellow]⚠️  Production mode: Databases and S3 will be RETAINED on stack deletion."
         )
         print(
-            f"[yellow]  To use development mode, set ENVIRONMENT='development' in cdk/config.py."
+            f"[yellow]   To use development mode, set ENVIRONMENT='development' in cdk/config.py."
         )
     else:
         print(
@@ -437,8 +433,10 @@ def destroy(
             f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager"
         )
         print()
-        print(f"[yellow]   These resources will continue to incur costs.")
-        print(f"[yellow]   To fully clean up, see instructions in cdk/README.md.")
+        print(
+            f"[yellow]   These resources will continue to incur costs. "
+            "To fully clean up, see instructions in cdk/README.md."
+        )
         print()
     else:
         print(

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -358,6 +358,15 @@ def deploy():
 
     region = str.lower(region)
 
+    # Add production mode warning
+    print(
+        f"[yellow]⚠️ Production mode: Databases and S3 will be RETAINED on stack deletion."
+    )
+    print(
+        f"[yellow]  To use development mode, set ENVIRONMENT='development' in cdk/config.py"
+    )
+    print()
+
     confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
     print()
 
@@ -400,6 +409,18 @@ def destroy(
     """
     Calls the cdk destroy command.
     """
+    # Add production mode warning
+    print(f"[yellow]⚠️ Production mode: The following resources will be RETAINED:")
+    print(
+        f"[yellow]   • RDS databases (chunkwise-evaluation-db, chunkwise-production-db)"
+    )
+    print(f"[yellow]   • S3 bucket (chunkwise-*)")
+    print(f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager")
+    print()
+    print(f"[yellow]   These resources will continue to incur costs")
+    print(f"[yellow]   To fully clean up, see instructions in cdk/README.md")
+    print()
+
     confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
     print()
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -275,7 +275,7 @@ def write_env_file(client_dir: str, values: dict):
         for key, val in existing.items():
             f.write(f"{key}={val}\n")
 
-    print(f"[green]✅ Successfully wrote {len(values)} values to {env_path}.")
+    console.print("[green]✅ Successfully wrote {len(values)} values to {env_path}.")
 
 
 def get_alb_dns(load_balancer_name, region=None):

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -12,6 +12,7 @@ from rich.table import Table
 import re
 from pathlib import Path
 import subprocess
+import importlib.util
 
 
 DEPLOY_RE = re.compile(
@@ -25,6 +26,14 @@ console = Console()
 
 CDK_DIR = Path(__file__).resolve().parent.parent / "cdk"
 CLIENT_DIR = Path(__file__).resolve().parent.parent / "client"
+
+# Load cdk/config.py dynamically
+CDK_CONFIG_PATH = Path(__file__).resolve().parent.parent / "cdk" / "config.py"
+spec = importlib.util.spec_from_file_location("cdk_config", CDK_CONFIG_PATH)
+cdk_config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cdk_config)
+
+env = cdk_config.ENVIRONMENT.lower()  # "production" or "development"
 
 
 def validate_key(key):
@@ -358,46 +367,52 @@ def deploy():
 
     region = str.lower(region)
 
-    # Add production mode warning
-    print(
-        f"[yellow]⚠️ Production mode: Databases and S3 will be RETAINED on stack deletion."
-    )
-    print(
-        f"[yellow]  To use development mode, set ENVIRONMENT='development' in cdk/config.py"
-    )
+    if env == "production":
+        # Add production mode warning
+        print(
+            f"[yellow]⚠️  Production mode: Databases and S3 will be RETAINED on stack deletion."
+        )
+        print(
+            f"[yellow]  To use development mode, set ENVIRONMENT='development' in cdk/config.py."
+        )
+    else:
+        print(
+            "[yellow]⚠️  Development mode: Stacks and secrets will be fully destroyed on teardown."
+        )
     print()
 
     confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
     print()
 
-    if confirm:
-        options = {
-            "region": "" if region == "my default" else region,
-        }
-        options_json = json.dumps(options)
-        account_id = boto3.client("sts").get_caller_identity().get("Account")
-
-        ensure_cdk_dependencies()
-
-        if region != "my default":
-            create_secret("chunkwise/openai-api-key", openai_api_key, region)
-            run_cdk_command("bootstrap", f"aws://{account_id}/{region}")
-        else:
-            create_secret("chunkwise/openai-api-key", openai_api_key)
-            run_cdk_command("bootstrap")
-
-        run_cdk_command(
-            "deploy",
-            "--all",
-            "--require-approval",
-            "never",
-            "-c",
-            f"options={options_json}",
-        )
-
-        print(f"[green]✅ Stacks successfullly deployed")
-    else:
+    if not confirm:
         print(f"[red]❌ Stack deployment cancelled")
+        return
+
+    options = {
+        "region": "" if region == "my default" else region,
+    }
+    options_json = json.dumps(options)
+    account_id = boto3.client("sts").get_caller_identity().get("Account")
+
+    ensure_cdk_dependencies()
+
+    if region != "my default":
+        create_secret("chunkwise/openai-api-key", openai_api_key, region)
+        run_cdk_command("bootstrap", f"aws://{account_id}/{region}")
+    else:
+        create_secret("chunkwise/openai-api-key", openai_api_key)
+        run_cdk_command("bootstrap")
+
+    run_cdk_command(
+        "deploy",
+        "--all",
+        "--require-approval",
+        "never",
+        "-c",
+        f"options={options_json}",
+    )
+
+    print(f"[green]✅ Stacks successfullly deployed")
 
 
 @app.command()
@@ -409,17 +424,27 @@ def destroy(
     """
     Calls the cdk destroy command.
     """
-    # Add production mode warning
-    print(f"[yellow]⚠️ Production mode: The following resources will be RETAINED:")
-    print(
-        f"[yellow]   • RDS databases (chunkwise-evaluation-db, chunkwise-production-db)"
-    )
-    print(f"[yellow]   • S3 bucket (chunkwise-*)")
-    print(f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager")
-    print()
-    print(f"[yellow]   These resources will continue to incur costs")
-    print(f"[yellow]   To fully clean up, see instructions in cdk/README.md")
-    print()
+
+    if env == "production":
+        # Add production mode warning
+        print(f"[yellow]⚠️  Production mode: The following resources will be RETAINED:")
+        print(f"[yellow]   • Network stack (VPC, Subnets, NAT Gateways, etc.)")
+        print(
+            f"[yellow]   • Database stack (2 RDS instances, subnet group, security groups, etc.)"
+        )
+        print(f"[yellow]   • S3 bucket (chunkwise-*)")
+        print(
+            f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager"
+        )
+        print()
+        print(f"[yellow]   These resources will continue to incur costs.")
+        print(f"[yellow]   To fully clean up, see instructions in cdk/README.md.")
+        print()
+    else:
+        print(
+            f"[yellow]⚠️  Development mode: All resources will be destroyed, including secrets."
+        )
+        print()
 
     confirm = Confirm.ask(f"[#00BCF7]Are you sure?")
     print()
@@ -429,18 +454,47 @@ def destroy(
     }
     options_json = json.dumps(options)
 
-    if confirm:
-        ensure_cdk_dependencies()
+    if not confirm:
+        print(f"[red]❌ Stack destruction cancelled.")
+        return
+
+    ensure_cdk_dependencies()
+
+    if env == "production":
+        # Only destroy ECS, Load Balancer, and Batch stacks
         run_cdk_command(
             "destroy", "ChunkwiseEcsStack", "--force", "-c", f"options={options_json}"
         )
-        run_cdk_command("destroy", "--all", "--force", "-c", f"options={options_json}")
+        run_cdk_command(
+            "destroy",
+            "ChunkwiseLoadBalancerStack",
+            "--force",
+            "-c",
+            f"options={options_json}",
+        )
+        run_cdk_command(
+            "destroy", "ChunkwiseBatchStack", "--force", "-c", f"options={options_json}"
+        )
+
+        print(
+            f"[green]✅ ECS, Load Balancer, and Batch stacks destroyed. "
+            "Network and Database stacks and secrets retained."
+        )
+    else:
+        # Destroy all stacks
+        run_cdk_command(
+            "destroy", "ChunkwiseEcsStack", "--force", "-c", f"options={options_json}"
+        )
+        run_cdk_command(
+            "destroy",
+            "--all",
+            "--force",
+            "-c",
+            f"options={options_json}",
+        )
         delete_secret("chunkwise/openai-api-key", region)
 
-        print(f"[green]✅ Stacks successfullly destroyed")
-
-    else:
-        print(f"[red]❌ Stack destruction cancelled.")
+        print(f"[green]✅ All stacks destroyed and secrets deleted.")
 
 
 @app.command()

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -633,7 +633,7 @@ def client_start():
 
 
 @app.command()
-def client_cmd(
+def client_run(
     region: Annotated[
         str, typer.Option(help="AWS region of the deployed stacks")
     ] = None,

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -230,7 +230,7 @@ def create_secret(secret_name, secret_value, region=None):
 
     except ClientError as e:
         if e.response["Error"]["Code"] == "ResourceExistsException":
-            print(f"[green]✅ Secret already exists")
+            print(f'[green]✅ Secret "{secret_name}" already exists.')
         else:
             raise
 
@@ -282,7 +282,7 @@ def write_env_file(client_dir: str, values: dict):
         for key, val in existing.items():
             f.write(f"{key}={val}\n")
 
-    print(f"[green]✅ Successfully wrote {len(values)} values to {env_path}")
+    print(f"[green]✅ Successfully wrote {len(values)} values to {env_path}.")
 
 
 def get_alb_dns(load_balancer_name, region=None):
@@ -306,7 +306,7 @@ def get_alb_dns(load_balancer_name, region=None):
 
     alb_dns = response["LoadBalancers"][0]["DNSName"]
 
-    print(f"[green]✅ Retrieved load balancer DNS")
+    print(f"[green]✅ Retrieved load balancer DNS.")
 
     return alb_dns
 
@@ -381,7 +381,7 @@ def deploy():
     print()
 
     if not confirm:
-        print(f"[red]❌ Stack deployment cancelled")
+        print(f"[red]❌ Stack deployment cancelled.")
         return
 
     options = {
@@ -408,7 +408,7 @@ def deploy():
         f"options={options_json}",
     )
 
-    print(f"[green]✅ Stacks successfullly deployed")
+    print(f"[green]✅ Stacks successfullly deployed.")
 
 
 @app.command()
@@ -426,9 +426,8 @@ def destroy(
         print(f"[yellow]⚠️  Production mode: The following resources will be RETAINED:")
         print(f"[yellow]   • Network stack (VPC, Subnets, NAT Gateways, etc.)")
         print(
-            f"[yellow]   • Database stack (2 RDS instances, subnet group, security groups, etc.)"
+            f"[yellow]   • Data stack (2 RDS instances, S3 bucket, DB subnet group, security groups, etc.)"
         )
-        print(f"[yellow]   • S3 bucket (chunkwise-*)")
         print(
             f"[yellow]   • Database credentials and OpenAI API key in Secrets Manager"
         )

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -221,7 +221,7 @@ def create_secret(secret_name, secret_value, region=None):
 
         client.create_secret(Name=secret_name, SecretString=secret_value)
 
-        print(f"[green]✅ AWS Secret created!")
+        print(f'[green]✅ AWS Secret "{secret_name}" created!')
 
     except ClientError as e:
         if e.response["Error"]["Code"] == "ResourceExistsException":


### PR DESCRIPTION
* Update `cdk/config.py` to dynamically configure CDK based on production/development environment; add helper functions for getting the deployment environment and resource removal policy
* Move the creation of S3 bucket from `ecs_stack.py` to `data_stack.py` (originally named `database_stack`) so that the ECS stack can be destroyed in production without affecting the S3 bucket.
* Update the data stack to dynamically set `deletion_protection` and `removal_policy` for RDS instances, and `removal_policy` and `auto_delete_objects` for S3 based on deployment environment mode
* Update CLI to read the environment mode variable from CDK and run different commands for destroy in production:
   - in production, only destroy application stacks (ecs, load balancer, batch)
   - in development, destroy all stacks + secrets 
   - add additional messages in CLI to warn users about the retention of foundation stacks and secrets in production on stack deploy and destroy
* Add a new `destroy-data` command in CLI to automate the deletion of all remaining resources (data stack, network stack, and secrets)
* Clean up CLI to use `console.print()` from Rich to avoid shadowing the built-in `print` function; remove unnecessary use of formatted strings for strings without interpolation; remove commented-out code; add missing doc strings; fix pylint issues
* Update `README.md` in both CDK and CLI to reflect above changes and include instructions for destroy in both production and development environment

